### PR TITLE
onepassword integration

### DIFF
--- a/frontend/src/routes/dashboard/[slug]/+page.ts
+++ b/frontend/src/routes/dashboard/[slug]/+page.ts
@@ -4,7 +4,7 @@ import { updateAppInfo } from '../../../stores/appsStore';
 export const ssr = false;
 export const prerender = false;
 
-export async function load({ params }) {
+export async function load({ params }: { params: { slug: string } }) {
 	const result = await updateAppInfo(params.slug);
 	if ('error' in result && result.error === true) {
 		error(404, result.message);

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod apps;
 mod docker;
 mod http;
 mod init_telemetry;
+mod onepassword;
 mod settings;
 mod state_machine;
 mod stop_flag;

--- a/src/onepassword/api.rs
+++ b/src/onepassword/api.rs
@@ -45,49 +45,49 @@ mod test {
     #[ignore]
     async fn test_get_item() {
         let result = request_item("n33i6edy47edsntxuj3a7lgiz4", "br47sla67ebp7e57lvpizumq4q").await;
-        assert_eq!(result.is_ok(), true);
+        assert!(result.is_ok());
         let result = result.unwrap();
 
         assert_eq!(result.id, "br47sla67ebp7e57lvpizumq4q");
         assert_eq!(result.vault.id, "n33i6edy47edsntxuj3a7lgiz4");
-        assert_eq!(result.has_field("username"), true);
+        assert!(result.has_field("username"));
         assert_eq!(
             result.get_field_value("username", None),
             Some("marvin@factorial.io")
         );
-        assert_eq!(result.get_password().is_some(), true);
+        assert!(result.get_password().is_some());
     }
 
     #[tokio::test]
     #[ignore] // This indicates the test won't run by default.
     async fn test_get_non_existent_item() {
         let result = request_item("n33i6edy47edsntxuj3a7lgiz4", "r47sla67ebp7e57lvpizumq4q").await;
-        assert_eq!(result.is_err(), true);
+        assert!(result.is_err());
     }
 
     #[tokio::test]
     #[ignore]
     async fn test_get_item_2() {
         let result = request_item("n33i6edy47edsntxuj3a7lgiz4", "7j7uxs6rx6w5ggku4zrhimwuye").await;
-        assert_eq!(result.is_ok(), true);
+        assert!(result.is_ok());
         let result = result.unwrap();
 
         assert_eq!(result.id, "7j7uxs6rx6w5ggku4zrhimwuye");
         assert_eq!(result.vault.id, "n33i6edy47edsntxuj3a7lgiz4");
         let password = result.get_password().unwrap();
-        assert_eq!(password.is_empty(), false);
+        assert!(!password.is_empty());
     }
 
     #[tokio::test]
     #[ignore]
     async fn test_get_item_from_section() {
         let result = request_item("n33i6edy47edsntxuj3a7lgiz4", "ida4izoksx4mwdpvt7wbbq6d7y").await;
-        assert_eq!(result.is_ok(), true);
+        assert!(result.is_ok());
         let result = result.unwrap();
 
         assert_eq!(result.id, "ida4izoksx4mwdpvt7wbbq6d7y");
         assert_eq!(result.vault.id, "n33i6edy47edsntxuj3a7lgiz4");
         let password = result.get_field_value("server", Some("Section A")).unwrap();
-        assert_eq!(password.is_empty(), false);
+        assert!(!password.is_empty());
     }
 }

--- a/src/onepassword/api.rs
+++ b/src/onepassword/api.rs
@@ -1,0 +1,93 @@
+use crate::settings::OnePasswordSettings;
+
+use super::item::Item;
+
+pub async fn get_item(
+    onepassword_settings: &OnePasswordSettings,
+    vault_id: &str,
+    item_id: &str,
+) -> anyhow::Result<Item> {
+    // Now we have everthing to do the actual lookup
+    let url = format!(
+        "{}/v1/vaults/{}/items/{}",
+        onepassword_settings.server, vault_id, item_id
+    );
+
+    let item: Item = reqwest::Client::new()
+        .get(&url)
+        .header(
+            "Authorization",
+            format!("Bearer {}", onepassword_settings.jwt_token),
+        )
+        .send()
+        .await?
+        .json()
+        .await?;
+
+    Ok(item)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    async fn request_item(vault_id: &str, item_id: &str) -> anyhow::Result<Item> {
+        let settings = OnePasswordSettings {
+            jwt_token: std::env::var("SCOTTY_OP_JWT_TEST_TOKEN")
+                .expect("SCOTTY_OP_JWT_TEST_TOKEN not set"),
+            server: "https://vault.factorial.io".to_string(),
+        };
+
+        get_item(&settings, vault_id, item_id).await
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn test_get_item() {
+        let result = request_item("n33i6edy47edsntxuj3a7lgiz4", "br47sla67ebp7e57lvpizumq4q").await;
+        assert_eq!(result.is_ok(), true);
+        let result = result.unwrap();
+
+        assert_eq!(result.id, "br47sla67ebp7e57lvpizumq4q");
+        assert_eq!(result.vault.id, "n33i6edy47edsntxuj3a7lgiz4");
+        assert_eq!(result.has_field("username"), true);
+        assert_eq!(
+            result.get_field_value("username", None),
+            Some("marvin@factorial.io")
+        );
+        assert_eq!(result.get_password().is_some(), true);
+    }
+
+    #[tokio::test]
+    #[ignore] // This indicates the test won't run by default.
+    async fn test_get_non_existent_item() {
+        let result = request_item("n33i6edy47edsntxuj3a7lgiz4", "r47sla67ebp7e57lvpizumq4q").await;
+        assert_eq!(result.is_err(), true);
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn test_get_item_2() {
+        let result = request_item("n33i6edy47edsntxuj3a7lgiz4", "7j7uxs6rx6w5ggku4zrhimwuye").await;
+        assert_eq!(result.is_ok(), true);
+        let result = result.unwrap();
+
+        assert_eq!(result.id, "7j7uxs6rx6w5ggku4zrhimwuye");
+        assert_eq!(result.vault.id, "n33i6edy47edsntxuj3a7lgiz4");
+        let password = result.get_password().unwrap();
+        assert_eq!(password.is_empty(), false);
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn test_get_item_from_section() {
+        let result = request_item("n33i6edy47edsntxuj3a7lgiz4", "ida4izoksx4mwdpvt7wbbq6d7y").await;
+        assert_eq!(result.is_ok(), true);
+        let result = result.unwrap();
+
+        assert_eq!(result.id, "ida4izoksx4mwdpvt7wbbq6d7y");
+        assert_eq!(result.vault.id, "n33i6edy47edsntxuj3a7lgiz4");
+        let password = result.get_field_value("server", Some("Section A")).unwrap();
+        assert_eq!(password.is_empty(), false);
+    }
+}

--- a/src/onepassword/item.rs
+++ b/src/onepassword/item.rs
@@ -1,4 +1,4 @@
-#[allow(dead_code)]
+#![allow(dead_code)]
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/onepassword/item.rs
+++ b/src/onepassword/item.rs
@@ -1,0 +1,102 @@
+#[allow(dead_code)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Item {
+    pub id: String,
+    pub title: String,
+    #[serde(default)]
+    pub tags: Vec<String>,
+    pub vault: Vault,
+    pub category: String,
+    #[serde(default)]
+    pub sections: Vec<Section>,
+    pub fields: Vec<Field>,
+    #[serde(default)]
+    pub files: Vec<File>,
+    #[serde(rename = "createdAt")]
+    pub created_at: String,
+    #[serde(rename = "updatedAt")]
+    pub updated_at: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Vault {
+    pub id: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Section {
+    pub id: String,
+    pub label: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Field {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub field_type: String,
+    pub purpose: Option<String>,
+    pub label: String,
+    pub value: Option<String>,
+    pub entropy: Option<f64>,
+    pub section: Option<FieldSection>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FieldSection {
+    pub id: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct File {
+    pub id: String,
+    pub name: String,
+    pub size: u64,
+    #[serde(rename = "content_path")]
+    pub content_path: String,
+}
+
+impl Item {
+    pub fn has_field(&self, field_id: &str) -> bool {
+        self.fields.iter().any(|field| field.id == field_id)
+    }
+
+    /// Get a field by its ID or label.
+    pub fn get_field(&self, field_id: &str, section_label: Option<&str>) -> Option<&Field> {
+        match section_label {
+            Some(section_label) => {
+                let section_id = &self
+                    .sections
+                    .iter()
+                    .find(|section| section.label == section_label)?
+                    .id;
+                self.fields.iter().find(|field| {
+                    (field.id == field_id || field.label == field_id)
+                        && field.section.as_ref().map(|section| section.id.as_str())
+                            == Some(section_id.as_str())
+                })
+            }
+            None => self
+                .fields
+                .iter()
+                .find(|field| (field.id == field_id || field.label == field_id)),
+        }
+    }
+
+    pub fn get_field_value(&self, field_id: &str, section_label: Option<&str>) -> Option<&str> {
+        self.get_field(field_id, section_label)
+            .and_then(|field| field.value.as_deref())
+    }
+
+    pub fn get_password(&self) -> Option<&str> {
+        self.fields
+            .iter()
+            .find(|field| {
+                field.id == "password"
+                    || field.field_type == "password"
+                    || field.field_type == "CONCEALED"
+            })
+            .and_then(|field| field.value.as_deref())
+    }
+}

--- a/src/onepassword/lookup.rs
+++ b/src/onepassword/lookup.rs
@@ -1,0 +1,134 @@
+use std::collections::HashMap;
+
+use tracing::error;
+
+use crate::settings::Settings;
+
+use super::api::get_item;
+
+pub async fn resolve_environment_variables(
+    settings: &Settings,
+    env: &HashMap<String, String>,
+) -> HashMap<String, String> {
+    let mut resolved = HashMap::new();
+    for (key, value) in env {
+        let resolved_value = if value.starts_with("op://") {
+            match lookup_password(settings, value).await {
+                Ok(resolved_value) => resolved_value,
+                Err(e) => {
+                    error!("Failed to resolve password for {}: {}", key, e);
+                    value.clone()
+                }
+            }
+        } else {
+            value.clone()
+        };
+        resolved.insert(key.clone(), resolved_value);
+    }
+    resolved
+}
+
+async fn lookup_password(settings: &Settings, op_uri: &str) -> anyhow::Result<String> {
+    // Remove "op://" prefix
+    let parts: Vec<&str> = op_uri
+        .strip_prefix("op://")
+        .ok_or_else(|| anyhow::anyhow!("Invalid op:// URI"))?
+        .split('/')
+        .collect();
+
+    // Check for required minimum parts
+    if parts.len() < 3 {
+        return Err(anyhow::anyhow!(
+            "Invalid op:// URI format - requires at least token_name/vault_id/item_id"
+        ));
+    }
+
+    let token_name = parts[0];
+    let vault_id = parts[1];
+    let item_id = parts[2];
+    let (section_name, field_id) = if parts.len() == 5 {
+        (Some(parts[3]), Some(parts[4]))
+    } else {
+        (None, parts.get(3).copied())
+    };
+
+    let onepassword_settings = match settings.onepassword.get(token_name) {
+        Some(s) => s,
+        None => {
+            return Err(anyhow::anyhow!(
+                "Failed to get OnePassword settings for token_name : {}",
+                token_name
+            ))
+        }
+    };
+
+    let item = get_item(onepassword_settings, vault_id, item_id).await?;
+
+    let result = match field_id {
+        Some(f) => item.get_field_value(f, section_name),
+        None => item.get_password(),
+    };
+
+    match result {
+        Some(v) => Ok(v.to_string()),
+        None => Err(anyhow::anyhow!(
+            "Failed to get field value for field_id : {:?}",
+            field_id
+        )),
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::settings::{OnePasswordSettings, Settings};
+    use maplit::hashmap;
+    use std::collections::HashMap;
+    use tokio;
+
+    #[tokio::test]
+    #[ignore]
+    async fn test_resolve_environment_variables() {
+        let mut env = HashMap::new();
+        env.insert("KEY1".to_string(), "value1".to_string());
+        env.insert(
+            "USERNAME".to_string(),
+            "op://factorial/n33i6edy47edsntxuj3a7lgiz4/ida4izoksx4mwdpvt7wbbq6d7y/username"
+                .to_string(),
+        );
+        env.insert(
+            "PASSWORD".to_string(),
+            "op://factorial/n33i6edy47edsntxuj3a7lgiz4/ida4izoksx4mwdpvt7wbbq6d7y".to_string(),
+        );
+        env.insert(
+            "SECTION_A_SERVER".to_string(),
+            "op://factorial/n33i6edy47edsntxuj3a7lgiz4/ida4izoksx4mwdpvt7wbbq6d7y/Section A/server"
+                .to_string(),
+        );
+        env.insert(
+            "SECTION_A_PASSWORD".to_string(),
+            "op://factorial/n33i6edy47edsntxuj3a7lgiz4/ida4izoksx4mwdpvt7wbbq6d7y/Section A/password".to_string(),
+        );
+
+        let onepassword_settings = OnePasswordSettings {
+            jwt_token: std::env::var("SCOTTY_OP_JWT_TEST_TOKEN")
+                .expect("SCOTTY_OP_JWT_TEST_TOKEN not set"),
+            server: "https://vault.factorial.io".to_string(),
+        };
+
+        let settings = Settings {
+            onepassword: hashmap! { "factorial".to_string() => onepassword_settings },
+            ..Settings::default()
+        };
+
+        let resolved = resolve_environment_variables(&settings, &env).await;
+
+        assert_eq!(resolved.get("KEY1").unwrap(), "value1");
+        assert_eq!(resolved.get("USERNAME").unwrap(), "scotty@factorial.io");
+        assert_eq!(resolved.get("PASSWORD").unwrap(), "my-little-secret");
+        assert_eq!(
+            resolved.get("SECTION_A_SERVER").unwrap(),
+            "https://scotty.test.url"
+        );
+        assert_eq!(resolved.get("SECTION_A_PASSWORD").unwrap(), "second-secret");
+    }
+}

--- a/src/onepassword/mod.rs
+++ b/src/onepassword/mod.rs
@@ -1,0 +1,3 @@
+pub mod api;
+pub mod item;
+pub mod lookup;

--- a/tests/test_docker_registry_password.yaml
+++ b/tests/test_docker_registry_password.yaml
@@ -44,3 +44,7 @@ traefik:
   certresolver: "myresolver"
 haproxy:
   use_tls: true
+onepassword:
+  test:
+    server: http://localhost:8000
+    jwt_token: "test_jwt"


### PR DESCRIPTION
Before passing the env-vars to the docker-compose.override.yml scotty will lookup passwords and other secrets, if the env-var value is a url with the op://-scheme, e.g. `op://token_name/vault_id/item_id/<Section Label>/<field_name>`

There's a new setting in the config files, where you can declare the available token_names, the connect server address and the actual token:

onepassword:
  test:
    server: http://localhost:8000
    jwt_token: "test_jwt"
This will provide the configuration for the token_name test.