### PR TITLE
feat: Add support for custom actions on apps

### DIFF
--- a/config/blueprints/drupal-lagoon.yaml
+++ b/config/blueprints/drupal-lagoon.yaml
@@ -16,9 +16,13 @@ apps:
                         - drush deploy --uri=$SCOTTY__PUBLIC_URL__NGINX
                 post_rebuild:
                     cli:
-                        - echo "Running drush deploy ..."
                         - drush deploy --uri=$SCOTTY__PUBLIC_URL__NGINX
                 post_run:
                     cli:
-                        - echo "Running drush uli ..."
                         - drush uli --uri=$SCOTTY__PUBLIC_URL__NGINX
+                drush:uli:
+                    cli:
+                        - drush uli --uri=$SCOTTY__PUBLIC_URL__NGINX
+                drush:deploy:
+                    cli:
+                        - drush deploy --uri=$SCOTTY__PUBLIC_URL__NGINX

--- a/config/blueprints/drupal-lagoon.yaml
+++ b/config/blueprints/drupal-lagoon.yaml
@@ -11,18 +11,27 @@ apps:
                 nginx: 8080
             actions:
                 post_create:
-                    cli:
-                        - echo "Running drush deploy ..."
-                        - drush deploy --uri=$SCOTTY__PUBLIC_URL__NGINX
+                    description: "Run drush deploy after the application is created"
+                    commands:
+                        cli:
+                            - drush deploy --uri=$SCOTTY__PUBLIC_URL__NGINX
                 post_rebuild:
-                    cli:
-                        - drush deploy --uri=$SCOTTY__PUBLIC_URL__NGINX
+                    description: "Run drush deploy after the application is rebuilt"
+                    commands:
+                        cli:
+                            - drush deploy --uri=$SCOTTY__PUBLIC_URL__NGINX
                 post_run:
-                    cli:
-                        - drush uli --uri=$SCOTTY__PUBLIC_URL__NGINX
+                    description: "Generate a one-time login link, after the application started successfully"
+                    commands:
+                        cli:
+                            - drush uli --uri=$SCOTTY__PUBLIC_URL__NGINX
                 drush:uli:
-                    cli:
-                        - drush uli --uri=$SCOTTY__PUBLIC_URL__NGINX
+                    description: "Generate a one-time login link"
+                    commands:
+                        cli:
+                            - drush uli --uri=$SCOTTY__PUBLIC_URL__NGINX
                 drush:deploy:
-                    cli:
-                        - drush deploy --uri=$SCOTTY__PUBLIC_URL__NGINX
+                    description: "Run drush deploy"
+                    commands:
+                        cli:
+                            - drush deploy --uri=$SCOTTY__PUBLIC_URL__NGINX

--- a/config/blueprints/nginx-lagoon.yaml
+++ b/config/blueprints/nginx-lagoon.yaml
@@ -1,33 +1,33 @@
 apps:
-  blueprints:
-    nginx-lagoon:
-      name: "NGINX using lagoon base images"
-      description: "A simple NGINX container using lagoon base images"
-      required_services:
-        - nginx
-      public_services:
-        nginx: 80
-      actions:
-        post_create:
-          nginx:
-            - echo "Hello, World from post_create"
-            - env
-        post_rebuild:
-          nginx:
-            - echo "Hello, World from post_rebuild"
-            - env
-        post_run:
-          nginx:
-            - echo "Hello, World from post_run"
-            - env
-        status:
-          nginx:
-            - echo "==== NGINX Status ===="
-            - nginx -v
-            - ps aux
-            - echo "==== End of Status ===="
-      action_descriptions:
-        post_create: "Initialize the application after creation"
-        post_rebuild: "Setup the application after rebuilding"
-        post_run: "Configure the application after starting"
-        status: "Display NGINX status information and running processes"
+    blueprints:
+        nginx-lagoon:
+            name: "NGINX using lagoon base images"
+            description: "A simple NGINX container using lagoon base images"
+            required_services:
+                - nginx
+            public_services:
+                nginx: 80
+            actions:
+                post_create:
+                    description: "Initialize the application after creation"
+                    commands:
+                        nginx:
+                            - echo "Hello, World from post_create"
+                            - env
+                post_rebuild:
+                    description: "Setup the application after rebuilding"
+                    commands:
+                        nginx:
+                            - echo "Hello, World from post_rebuild"
+                            - env
+                post_run:
+                    description: "Configure the application after starting"
+                    commands:
+                        nginx:
+                            - echo "Hello, World from post_run"
+                            - env
+                status:
+                    description: "Display NGINX status information and running processes"
+                    commands:
+                        nginx:
+                            - nginx -v

--- a/config/blueprints/nginx-lagoon.yaml
+++ b/config/blueprints/nginx-lagoon.yaml
@@ -1,25 +1,33 @@
 apps:
-    blueprints:
-        nginx-lagoon:
-            name: "NGINX using lagoon base images"
-            description: "A simple NGINX container using lagoon base images"
-            required_services:
-                - nginx
-            public_services:
-                nginx: 80
-            actions:
-                post_create:
-                    nginx:
-                        - echo "Hello, World from post_create"
-                        - env
-                post_rebuild:
-                    nginx:
-                        - echo "Hello, World from post_rebuild"
-                        - env
-                post_run:
-                    nginx:
-                        - echo "Hello, World from post_run"
-                        - env
-                status:
-                    nginx:
-                        - nginx -v
+  blueprints:
+    nginx-lagoon:
+      name: "NGINX using lagoon base images"
+      description: "A simple NGINX container using lagoon base images"
+      required_services:
+        - nginx
+      public_services:
+        nginx: 80
+      actions:
+        post_create:
+          nginx:
+            - echo "Hello, World from post_create"
+            - env
+        post_rebuild:
+          nginx:
+            - echo "Hello, World from post_rebuild"
+            - env
+        post_run:
+          nginx:
+            - echo "Hello, World from post_run"
+            - env
+        status:
+          nginx:
+            - echo "==== NGINX Status ===="
+            - nginx -v
+            - ps aux
+            - echo "==== End of Status ===="
+      action_descriptions:
+        post_create: "Initialize the application after creation"
+        post_rebuild: "Setup the application after rebuilding"
+        post_run: "Configure the application after starting"
+        status: "Display NGINX status information and running processes"

--- a/config/blueprints/nginx-lagoon.yaml
+++ b/config/blueprints/nginx-lagoon.yaml
@@ -1,22 +1,25 @@
 apps:
-  blueprints:
-    nginx-lagoon:
-      name: "NGINX using lagoon base images"
-      description: "A simple NGINX container using lagoon base images"
-      required_services:
-        - nginx
-      public_services:
-        nginx: 80
-      actions:
-        post_create:
-          nginx:
-            - echo "Hello, World from post_create"
-            - env
-        post_rebuild:
-          nginx:
-            - echo "Hello, World from post_rebuild"
-            - env
-        post_run:
-          nginx:
-            - echo "Hello, World from post_run"
-            - env
+    blueprints:
+        nginx-lagoon:
+            name: "NGINX using lagoon base images"
+            description: "A simple NGINX container using lagoon base images"
+            required_services:
+                - nginx
+            public_services:
+                nginx: 80
+            actions:
+                post_create:
+                    nginx:
+                        - echo "Hello, World from post_create"
+                        - env
+                post_rebuild:
+                    nginx:
+                        - echo "Hello, World from post_rebuild"
+                        - env
+                post_run:
+                    nginx:
+                        - echo "Hello, World from post_run"
+                        - env
+                status:
+                    nginx:
+                        - nginx -v

--- a/frontend/src/components/custom-actions-dropdown.svelte
+++ b/frontend/src/components/custom-actions-dropdown.svelte
@@ -1,0 +1,121 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { apiCall } from '$lib';
+	import type { App } from '../types';
+	import { goto } from '$app/navigation';
+
+	export let app: App;
+
+	let customActions: unknown[] = [];
+	let isLoading = true;
+	let currentTaskId: string | null = null;
+	let currentAction: string | null = null;
+
+	onMount(async () => {
+		if (app.settings?.app_blueprint) {
+			try {
+				// Fetch all blueprints and filter for the one we need
+				const result = await apiCall('blueprints');
+				if (result && result.blueprints && result.blueprints[app.settings.app_blueprint]) {
+					const blueprint = result.blueprints[app.settings.app_blueprint];
+					// Filter for custom actions only
+					// The API returns action names as "Custom(action_name)"
+					// We need to extract the actual action name
+					customActions = Object.keys(blueprint.actions || {})
+						.filter((key) => !key.startsWith('post_'))
+						.map((key) => ({
+							name: key,
+							description: blueprint.actions[key].description
+						}));
+				} else {
+					console.warn(
+						`Blueprint ${app.settings.app_blueprint} not found or has no actions`
+					);
+				}
+			} catch (err) {
+				console.error('Error loading blueprints:', err);
+			} finally {
+				isLoading = false;
+			}
+		} else {
+			isLoading = false;
+		}
+	});
+
+	async function triggerCustomAction(actionName: string) {
+		if (currentTaskId !== null || !isSupported()) return;
+
+		try {
+			currentAction = actionName;
+			const result = await apiCall(`apps/${app.name}/actions`, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json'
+				},
+				body: JSON.stringify({ action_name: actionName })
+			});
+
+			// RunningAppContext contains a task field with the task details
+			if (result && result.task && result.task.id) {
+				currentTaskId = result.task.id;
+				goto(`/tasks/${currentTaskId}`);
+			} else {
+				console.error('Unexpected API response:', result);
+				throw new Error('Invalid response from server');
+			}
+		} catch (err) {
+			console.error('Error triggering custom action:', err);
+			currentAction = null;
+		}
+	}
+
+	// Check if the app is in a supported state for custom actions
+	function isSupported() {
+		return app.status === 'Running' && app.settings?.app_blueprint;
+	}
+</script>
+
+{#if isLoading}
+	<div class="btn btn-sm join-item loading">Loading actions...</div>
+{:else if customActions.length > 0}
+	<div class="dropdown">
+		<div
+			tabindex="0"
+			role="button"
+			class="btn btn-sm join-item {currentTaskId !== null || !isSupported()
+				? 'btn-disabled'
+				: ''}"
+		>
+			{#if currentAction}
+				<span class="loading loading-spinner loading-xs mr-1"></span>
+				Running {currentAction}...
+			{:else}
+				Custom Actions
+			{/if}
+		</div>
+		<ul
+			tabindex="0"
+			class="dropdown-content menu bg-base-100 rounded-box z-1 w-52 p-2 shadow-sm"
+		>
+			{#each customActions as action (action)}
+				<li>
+					<button
+						on:click={() => triggerCustomAction(action.name)}
+						data-tip={action.description}
+						class="tooltip tooltip-right"
+						disabled={currentTaskId !== null || !isSupported()}
+					>
+						{action.name}
+					</button>
+				</li>
+			{/each}
+		</ul>
+	</div>
+{:else if !isLoading && app.settings?.app_blueprint && isSupported()}
+	<div
+		class="btn btn-sm join-item btn-disabled tooltip tooltip-bottom"
+		data-tip="No custom actions defined in blueprint"
+	>
+		Custom Actions
+	</div>
+{/if}

--- a/frontend/src/routes/dashboard/[slug]/+page.svelte
+++ b/frontend/src/routes/dashboard/[slug]/+page.svelte
@@ -14,6 +14,7 @@
 	import { onMount } from 'svelte';
 	import { setTitle } from '../../../stores/titleStore';
 	import Pill from '../../../components/pill.svelte';
+	import CustomActionsDropdown from '../../../components/custom-actions-dropdown.svelte';
 
 	/** @type {import('./$types').PageData} */
 	export let data: App;
@@ -81,8 +82,6 @@
 		}
 		return value;
 	}
-
-	console.log(data);
 </script>
 
 <PageHeader>
@@ -93,17 +92,23 @@
 </PageHeader>
 
 <h3 class="text-xl mt-16 mb-4">Available Actions</h3>
-<div class="join">
-	{#each actions as action (action)}
-		<button
-			disabled={current_task !== null || !isSupported()}
-			class="btn btn-sm join-item"
-			on:click={() => handleClick(action)}
-			>{#if action === current_action}
-				<span class="loading loading-spinner"></span>
-			{/if}{action}</button
-		>
-	{/each}
+<div class="flex flex-wrap items-center gap-2">
+	<div class="join">
+		{#each actions as action (action)}
+			<button
+				disabled={current_task !== null || !isSupported()}
+				class="btn btn-sm join-item"
+				on:click={() => handleClick(action)}
+				>{#if action === current_action}
+					<span class="loading loading-spinner"></span>
+				{/if}{action}</button
+			>
+		{/each}
+	</div>
+	{#if isSupported()}
+		<div class="divider divider-horizontal mx-0"></div>
+		<CustomActionsDropdown app={data} />
+	{/if}
 </div>
 <h3 class="text-xl mt-16 mb-4">Available Services</h3>
 <table class="table">

--- a/frontend/src/routes/tasks/[slug]/+page.svelte
+++ b/frontend/src/routes/tasks/[slug]/+page.svelte
@@ -15,7 +15,6 @@
 	});
 
 	tasks.subscribe((new_tasks) => {
-		console.log(new_tasks, data.id);
 		data = Object.values(new_tasks).find((t) => t.id === data.id) || data;
 	});
 </script>

--- a/scotty-core/src/apps/shared_app_list.rs
+++ b/scotty-core/src/apps/shared_app_list.rs
@@ -49,6 +49,10 @@ impl SharedAppList {
         Ok(())
     }
 
+    pub async fn has_app(&self, app_name: &str) -> bool {
+        self.apps.read().await.contains_key(app_name)
+    }
+
     pub async fn get_app(&self, app_name: &str) -> Option<AppData> {
         let t = self.apps.read().await;
         t.get(app_name).cloned()

--- a/scotty-core/src/notification_types/mod.rs
+++ b/scotty-core/src/notification_types/mod.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
 use crate::apps::app_data::AppData;
+use crate::settings::app_blueprint::ActionName;
 use crate::utils::serde::{deserialize_app_name, serialize_app_name};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, utoipa::ToSchema, Hash, Eq)]
@@ -40,6 +41,7 @@ pub enum MessageType {
     AppDestroyed,
     AppPurged,
     AppRebuilt,
+    AppCustomActionCompleted(ActionName),
     Custom(String),
 }
 impl MessageType {
@@ -51,6 +53,11 @@ impl MessageType {
             MessageType::AppDestroyed => format!("App {} destroyed", app.name),
             MessageType::AppPurged => format!("App {} purged", app.name),
             MessageType::AppRebuilt => format!("App {} rebuilt", app.name),
+            MessageType::AppCustomActionCompleted(action_name) => format!(
+                "Executed custom action {:?} on app {}",
+                action_name, app.name
+            ),
+
             MessageType::Custom(msg) => msg.clone(),
         }
     }

--- a/scotty-core/src/settings/app_blueprint.rs
+++ b/scotty-core/src/settings/app_blueprint.rs
@@ -65,6 +65,8 @@ pub struct AppBlueprint {
     pub actions: HashMap<ActionName, HashMap<String, Vec<String>>>,
     pub required_services: Vec<String>,
     pub public_services: Option<HashMap<String, u16>>,
+    #[serde(default)]
+    pub action_descriptions: HashMap<ActionName, String>,
 }
 
 #[derive(Deserialize)]
@@ -74,6 +76,8 @@ pub struct AppBlueprintShadow {
     pub actions: HashMap<ActionName, HashMap<String, Vec<String>>>,
     pub required_services: Vec<String>,
     pub public_services: Option<HashMap<String, u16>>,
+    #[serde(default)]
+    pub action_descriptions: HashMap<ActionName, String>,
 }
 
 pub struct AppBlueprintValidationError {
@@ -127,6 +131,7 @@ impl std::convert::TryFrom<AppBlueprintShadow> for AppBlueprint {
             actions: shadow.actions,
             required_services: shadow.required_services,
             public_services: shadow.public_services,
+            action_descriptions: shadow.action_descriptions,
         })
     }
 }

--- a/scotty-core/src/settings/app_blueprint.rs
+++ b/scotty-core/src/settings/app_blueprint.rs
@@ -79,7 +79,6 @@ impl Action {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema, utoipa::ToResponse)]
-#[allow(unused)]
 pub struct AppBlueprint {
     pub name: String,
     pub description: String,

--- a/scotty-core/src/settings/app_blueprint.rs
+++ b/scotty-core/src/settings/app_blueprint.rs
@@ -125,9 +125,7 @@ impl AppBlueprint {
         self.get_action(action_name)
             .map(|action| action.commands.keys().map(|s| s.as_str()).collect())
     }
-}
 
-impl AppBlueprint {
     pub fn validate(&self) -> Result<(), AppBlueprintValidationError> {
         // Validate that all public services are in the required services list
         for public_service in self

--- a/scotty/src/api/error.rs
+++ b/scotty/src/api/error.rs
@@ -87,6 +87,11 @@ impl AppError {
             AppError::InternalServerError(_) => StatusCode::INTERNAL_SERVER_ERROR,
             AppError::AppNotFound(_) => StatusCode::NOT_FOUND,
             AppError::TaskNotFound(_) => StatusCode::NOT_FOUND,
+            AppError::AppSettingsNotFound(_) => StatusCode::NOT_FOUND,
+            AppError::CantCreateAppWithScottyYmlFile => StatusCode::BAD_REQUEST,
+            AppError::CantAdoptAppWithExistingSettings(_) => StatusCode::BAD_REQUEST,
+            AppError::AppNotRunning(_) => StatusCode::CONFLICT,
+            AppError::ActionNotFound(_) => StatusCode::NOT_FOUND,
             _ => StatusCode::INTERNAL_SERVER_ERROR,
         };
 

--- a/scotty/src/api/error.rs
+++ b/scotty/src/api/error.rs
@@ -64,6 +64,12 @@ pub enum AppError {
     #[error("App settings not found for app: {0}")]
     AppSettingsNotFound(String),
 
+    #[error("App is not running: {0}")]
+    AppNotRunning(String),
+
+    #[error("{0}")]
+    ActionNotFound(String),
+
     #[error("Found invalid notification service ids: {0}")]
     InvalidNotificationServiceIds(String),
 

--- a/scotty/src/api/handlers/apps/custom_action.rs
+++ b/scotty/src/api/handlers/apps/custom_action.rs
@@ -1,0 +1,66 @@
+use axum::{
+    debug_handler,
+    extract::{Path, State},
+    response::IntoResponse,
+    Json,
+};
+use serde::{Deserialize, Serialize};
+use tracing::info;
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use crate::{
+    api::error::AppError, app_state::SharedAppState,
+    docker::run_app_custom_action::run_app_custom_action,
+};
+use scotty_core::{
+    settings::app_blueprint::ActionName, tasks::running_app_context::RunningAppContext,
+};
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct CustomActionPayload {
+    pub action_name: String,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct CustomActionResponse {
+    pub task_id: Uuid,
+}
+
+#[debug_handler]
+#[utoipa::path(
+    post,
+    path = "/api/v1/apps/{app_name}/actions",
+    request_body = CustomActionPayload,
+    responses(
+        (status = 200, response = inline(RunningAppContext)),
+        (status = 401, description = "Access token is missing or invalid"),
+        (status = 404, description = "App not found"),
+        (status = 500, description = "Internal server error"),
+    ),
+    security(
+        ("bearerAuth" = [])
+    )
+)]
+pub async fn run_custom_action_handler(
+    State(state): State<SharedAppState>,
+    Path(app_name): Path<String>,
+    Json(payload): Json<CustomActionPayload>,
+) -> Result<impl IntoResponse, AppError> {
+    info!(
+        "Starting custom action '{}' for app '{}'",
+        payload.action_name, app_name
+    );
+
+    // Validate app exists and get the app
+    let app = match state.apps.get_app(&app_name).await {
+        Some(app) => app,
+        None => return Err(AppError::AppNotFound(app_name)),
+    };
+
+    // Create a task for running the custom action
+    let app_data =
+        run_app_custom_action(state, &app, ActionName::Custom(payload.action_name)).await?;
+
+    Ok(Json(app_data))
+}

--- a/scotty/src/api/handlers/apps/mod.rs
+++ b/scotty/src/api/handlers/apps/mod.rs
@@ -1,4 +1,5 @@
 pub mod create;
+pub mod custom_action;
 pub mod list;
 pub mod notify;
 pub mod run;

--- a/scotty/src/api/router.rs
+++ b/scotty/src/api/router.rs
@@ -28,6 +28,7 @@ use utoipa_redoc::{Redoc, Servable};
 use utoipa_swagger_ui::SwaggerUi;
 
 use crate::api::handlers::apps::create::__path_create_app_handler;
+use crate::api::handlers::apps::custom_action::__path_run_custom_action_handler;
 use crate::api::handlers::apps::list::__path_list_apps_handler;
 use crate::api::handlers::apps::list::list_apps_handler;
 use crate::api::handlers::apps::notify::__path_add_notification_handler;
@@ -56,6 +57,7 @@ use scotty_core::tasks::task_details::TaskDetails;
 
 use super::basic_auth::auth;
 use super::handlers::apps::create::create_app_handler;
+use super::handlers::apps::custom_action::run_custom_action_handler;
 use super::handlers::apps::notify::add_notification_handler;
 use super::handlers::apps::notify::remove_notification_handler;
 use super::handlers::apps::run::adopt_app_handler;
@@ -93,6 +95,7 @@ use super::handlers::tasks::task_list_handler;
         add_notification_handler,
         remove_notification_handler,
         adopt_app_handler,
+        run_custom_action_handler,
     ),
     components(
         schemas(
@@ -157,6 +160,10 @@ impl ApiRoutes {
             .route(
                 "/api/v1/apps/notify/remove",
                 post(remove_notification_handler),
+            )
+            .route(
+                "/api/v1/apps/{app_name}/actions",
+                post(run_custom_action_handler),
             )
             .route_layer(middleware::from_fn_with_state(state.clone(), auth));
 

--- a/scotty/src/docker/mod.rs
+++ b/scotty/src/docker/mod.rs
@@ -7,6 +7,7 @@ pub mod loadbalancer;
 pub mod purge_app;
 pub mod rebuild_app;
 pub mod run_app;
+pub mod run_app_custom_action;
 pub mod setup;
 pub mod state_machine_handlers;
 pub mod stop_app;

--- a/scotty/src/docker/run_app_custom_action.rs
+++ b/scotty/src/docker/run_app_custom_action.rs
@@ -1,0 +1,131 @@
+use std::sync::Arc;
+
+use tracing::{info, instrument};
+
+use crate::{
+    api::error::AppError,
+    app_state::SharedAppState,
+    docker::{
+        helper::run_sm,
+        state_machine_handlers::{
+            context::Context, run_docker_login_handler::RunDockerLoginHandler,
+            run_post_actions_handler::RunPostActionsHandler,
+            set_finished_handler::SetFinishedHandler,
+            update_app_data_handler::UpdateAppDataHandler,
+        },
+    },
+    state_machine::StateMachine,
+};
+use scotty_core::{
+    notification_types::{Message, MessageType},
+    settings::app_blueprint::ActionName,
+    tasks::running_app_context::RunningAppContext,
+};
+
+use scotty_core::apps::app_data::{AppData, AppStatus};
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+enum RunAppCustomActionStates {
+    RunDockerLogin,
+    RunPostActions,
+    UpdateAppData,
+    SetFinished,
+    Done,
+}
+
+#[instrument(skip(state))]
+pub async fn run_app_custom_action_prepare(
+    state: &SharedAppState,
+    app: &AppData,
+    action: ActionName,
+) -> anyhow::Result<StateMachine<RunAppCustomActionStates, Context>> {
+    if app.status != AppStatus::Running {
+        return Err(AppError::AppNotRunning(app.name.to_string()).into());
+    }
+
+    // Check if the app has a blueprint with the custom action
+    let app_settings = app.settings.clone();
+    if app_settings.is_none() {
+        return Err(AppError::AppSettingsNotFound(app.name.to_string()).into());
+    }
+
+    let blueprint_name = &app_settings.as_ref().unwrap().app_blueprint;
+    if blueprint_name.is_none() {
+        return Err(
+            AppError::AppBlueprintMismatch("App doesn't have a blueprint".to_string()).into(),
+        );
+    }
+
+    let blueprint = state
+        .settings
+        .apps
+        .blueprints
+        .get(blueprint_name.as_ref().unwrap());
+    if blueprint.is_none() {
+        return Err(
+            AppError::AppBlueprintNotFound(blueprint_name.as_ref().unwrap().clone()).into(),
+        );
+    }
+
+    // Verify the custom action exists in the blueprint
+    if !blueprint.unwrap().actions.contains_key(&action) {
+        return Err(AppError::ActionNotFound(format!(
+            "Action not found in blueprint: {:?}",
+            action
+        ))
+        .into());
+    }
+
+    info!("Running custom action {:?} on app {}", action, app.name);
+
+    let mut sm = StateMachine::new(
+        RunAppCustomActionStates::RunDockerLogin,
+        RunAppCustomActionStates::Done,
+    );
+
+    sm.add_handler(
+        RunAppCustomActionStates::RunDockerLogin,
+        Arc::new(RunDockerLoginHandler::<RunAppCustomActionStates> {
+            next_state: RunAppCustomActionStates::RunPostActions,
+            registry: app.get_registry(),
+        }),
+    );
+
+    sm.add_handler(
+        RunAppCustomActionStates::RunPostActions,
+        Arc::new(RunPostActionsHandler::<RunAppCustomActionStates> {
+            next_state: RunAppCustomActionStates::UpdateAppData,
+            action,
+            settings: app.settings.clone(),
+        }),
+    );
+    sm.add_handler(
+        RunAppCustomActionStates::UpdateAppData,
+        Arc::new(UpdateAppDataHandler::<RunAppCustomActionStates> {
+            next_state: RunAppCustomActionStates::SetFinished,
+        }),
+    );
+    sm.add_handler(
+        RunAppCustomActionStates::SetFinished,
+        Arc::new(SetFinishedHandler::<RunAppCustomActionStates> {
+            next_state: RunAppCustomActionStates::Done,
+            notification: Some(Message::new(MessageType::AppStarted, app)),
+        }),
+    );
+
+    Ok(sm)
+}
+
+#[instrument(skip(app_state))]
+pub async fn run_app_custom_action(
+    app_state: SharedAppState,
+    app: &AppData,
+    action: ActionName,
+) -> anyhow::Result<RunningAppContext> {
+    if app.status == AppStatus::Unsupported {
+        return Err(AppError::OperationNotSupportedForLegacyApp(app.name.clone()).into());
+    }
+
+    let sm = run_app_custom_action_prepare(&app_state, app, action).await?;
+    run_sm(app_state, app, sm).await
+}

--- a/scotty/src/docker/run_app_custom_action.rs
+++ b/scotty/src/docker/run_app_custom_action.rs
@@ -95,7 +95,7 @@ pub async fn run_app_custom_action_prepare(
         RunAppCustomActionStates::RunPostActions,
         Arc::new(RunPostActionsHandler::<RunAppCustomActionStates> {
             next_state: RunAppCustomActionStates::UpdateAppData,
-            action,
+            action: action.clone(),
             settings: app.settings.clone(),
         }),
     );
@@ -109,7 +109,10 @@ pub async fn run_app_custom_action_prepare(
         RunAppCustomActionStates::SetFinished,
         Arc::new(SetFinishedHandler::<RunAppCustomActionStates> {
             next_state: RunAppCustomActionStates::Done,
-            notification: Some(Message::new(MessageType::AppStarted, app)),
+            notification: Some(Message::new(
+                MessageType::AppCustomActionCompleted(action.clone()),
+                app,
+            )),
         }),
     );
 

--- a/scotty/src/docker/state_machine_handlers/run_post_actions_handler.rs
+++ b/scotty/src/docker/state_machine_handlers/run_post_actions_handler.rs
@@ -68,8 +68,8 @@ where
         let environment = context.app_data.get_environment();
         let augmented_env = context.app_data.augment_environment(HashMap::new());
 
-        if let Some(service_script_mapping) = selected_action {
-            for (service, script) in service_script_mapping.iter() {
+        if let Some(action) = selected_action {
+            for (service, script) in &action.commands {
                 let mut augmented_script = Vec::new();
                 for (key, value) in augmented_env.iter() {
                     augmented_script.push(format!("export {}={}", key, value));

--- a/scotty/src/settings/config.rs
+++ b/scotty/src/settings/config.rs
@@ -185,10 +185,7 @@ mod tests {
         let blueprint = settings.apps.blueprints.get("nginx-lagoon").unwrap();
         assert_eq!(blueprint.name, "NGINX using lagoon base images");
         let script = blueprint
-            .actions
-            .get(&ActionName::PostCreate)
-            .unwrap()
-            .get("nginx")
+            .get_commands_for_service(&ActionName::PostCreate, "nginx")
             .unwrap();
         assert_eq!(script[0], "echo \"Hello, World!\"".to_string());
     }

--- a/scotty/tests/test_docker_registry_password.yaml
+++ b/scotty/tests/test_docker_registry_password.yaml
@@ -21,14 +21,17 @@ apps:
                 - nginx
             actions:
                 post_create:
-                    nginx:
-                        - echo "Hello, World!"
+                    commands:
+                        nginx:
+                            - echo "Hello, World!"
                 post_rebuild:
-                    nginx:
-                        - echo "Hello, World!"
+                    commands:
+                        nginx:
+                            - echo "Hello, World!"
                 post_run:
-                    nginx:
-                        - echo "Hello, World!"
+                    commands:
+                        nginx:
+                            - echo "Hello, World!"
 docker:
     connection: local # local, socket or http, see bollard docs
     registries:

--- a/scottyctl/src/cli.rs
+++ b/scottyctl/src/cli.rs
@@ -76,6 +76,10 @@ pub enum Commands {
     #[command(name = "blueprint:list")]
     BlueprintList,
 
+    /// Show detailed information about a blueprint
+    #[command(name = "blueprint:info")]
+    BlueprintInfo(BlueprintInfoCommand),
+
     /// Show shell completion script.
     #[command(name = "completion")]
     Completion(CompletionCommand),
@@ -92,6 +96,12 @@ pub struct CompletionCommand {
 
 #[derive(Debug, Parser)]
 pub struct BlueprintListCommand {}
+
+#[derive(Debug, Parser)]
+pub struct BlueprintInfoCommand {
+    /// Name of the blueprint
+    pub blueprint_name: String,
+}
 
 #[derive(Debug, Parser)]
 pub struct RunCommand {

--- a/scottyctl/src/cli.rs
+++ b/scottyctl/src/cli.rs
@@ -60,6 +60,9 @@ pub enum Commands {
     /// Destroy an app
     #[command(name = "app:destroy")]
     Destroy(DestroyCommand),
+    /// Run a custom action on an app
+    #[command(name = "app:action")]
+    Action(ActionCommand),
 
     /// setup notificattions to other services
     #[command(name = "notify:add")]
@@ -117,6 +120,15 @@ pub struct NotifyAddCommand {
 }
 
 pub type NotifyRemoveCommand = NotifyAddCommand;
+
+#[derive(Debug, Parser)]
+pub struct ActionCommand {
+    /// Name of the app
+    pub app_name: String,
+
+    /// Name of the custom action to run
+    pub action_name: String,
+}
 
 #[derive(Debug, Parser)]
 pub struct CreateCommand {

--- a/scottyctl/src/commands/apps.rs
+++ b/scottyctl/src/commands/apps.rs
@@ -5,8 +5,8 @@ use tabled::{builder::Builder, settings::Style};
 use crate::{
     api::{get, get_or_post, wait_for_task},
     cli::{
-        AdoptCommand, CreateCommand, DestroyCommand, InfoCommand, PurgeCommand, RebuildCommand,
-        RunCommand, StopCommand,
+        ActionCommand, AdoptCommand, CreateCommand, DestroyCommand, InfoCommand, PurgeCommand,
+        RebuildCommand, RunCommand, StopCommand,
     },
     context::{AppContext, ServerSettings},
     utils::{
@@ -197,6 +197,44 @@ pub async fn destroy_app(context: &AppContext, cmd: &DestroyCommand) -> anyhow::
         ));
 
         Ok(format!("App {} destroyed", &cmd.app_name))
+    })
+    .await
+}
+
+pub async fn run_custom_action(context: &AppContext, cmd: &ActionCommand) -> anyhow::Result<()> {
+    let ui = context.ui();
+    ui.new_status_line(format!(
+        "Running custom action {} on app {}...",
+        &cmd.action_name.yellow(),
+        &cmd.app_name.yellow()
+    ));
+    ui.run(async || {
+        let payload = serde_json::json!({
+            "action_name": cmd.action_name
+        });
+
+        let result = get_or_post(
+            context.server(),
+            &format!("apps/{}/actions", &cmd.app_name),
+            "POST",
+            Some(payload),
+        )
+        .await?;
+
+        let app_context: RunningAppContext =
+            serde_json::from_value(result).context("Failed to parse context from API")?;
+
+        wait_for_task(context.server(), &app_context, ui).await?;
+
+        let app_data = get_app_info(context.server(), &app_context.app_data.name).await?;
+
+        ui.success(format!(
+            "Custom action {} completed successfully for app {}",
+            &cmd.action_name.yellow(),
+            &cmd.app_name.yellow()
+        ));
+
+        format_app_info(&app_data)
     })
     .await
 }

--- a/scottyctl/src/commands/blueprints.rs
+++ b/scottyctl/src/commands/blueprints.rs
@@ -111,18 +111,15 @@ pub async fn blueprint_info(
                 _ => continue,
             };
 
-            let description = blueprint
-                .action_descriptions
-                .get(&action)
-                .map(|s| s.as_str())
+            let action_obj = blueprint.actions.get(&action);
+            let description = action_obj
+                .map(|a| a.description.as_str())
                 .unwrap_or("Lifecycle action");
-
-            let services_map = blueprint.actions.get(&action);
 
             // Format the services and commands in a readable way
             let mut services_commands = String::new();
-            if let Some(service_commands) = services_map {
-                for (i, (service, commands)) in service_commands.iter().enumerate() {
+            if let Some(action_obj) = action_obj {
+                for (i, (service, commands)) in action_obj.commands.iter().enumerate() {
                     if i > 0 {
                         services_commands.push_str("\n\n");
                     }
@@ -145,18 +142,14 @@ pub async fn blueprint_info(
         }
 
         // Add custom actions
-        for (action, services) in &blueprint.actions {
+        for (action, action_obj) in &blueprint.actions {
             match action {
                 ActionName::Custom(name) => {
-                    let description = blueprint
-                        .action_descriptions
-                        .get(action)
-                        .map(|s| s.as_str())
-                        .unwrap_or("Custom action");
+                    let description = action_obj.description.as_str();
 
                     // Format the services and commands in a readable way
                     let mut services_commands = String::new();
-                    for (i, (service, commands)) in services.iter().enumerate() {
+                    for (i, (service, commands)) in action_obj.commands.iter().enumerate() {
                         if i > 0 {
                             services_commands.push_str("\n\n");
                         }

--- a/scottyctl/src/commands/blueprints.rs
+++ b/scottyctl/src/commands/blueprints.rs
@@ -42,7 +42,7 @@ pub async fn list_blueprints(context: &AppContext) -> anyhow::Result<()> {
     .await
 }
 
-fn format_services_command(commands: &HashMap<String, Vec<String>>) -> String {
+fn format_services_commands(commands: &HashMap<String, Vec<String>>) -> String {
     let mut services_commands = String::new();
     for (i, (service, commands)) in commands.iter().enumerate() {
         if i > 0 {
@@ -131,7 +131,7 @@ pub async fn blueprint_info(
             };
 
             // Format the services and commands in a readable way
-            let services_commands = format_services_command(&action_obj.commands);
+            let services_commands = format_services_commands(&action_obj.commands);
 
             builder.push_record(vec![
                 &action_name.dimmed().to_string(),

--- a/scottyctl/src/commands/blueprints.rs
+++ b/scottyctl/src/commands/blueprints.rs
@@ -118,27 +118,24 @@ pub async fn blueprint_info(
 
         // Add lifecycle actions
         for action in lifecycle_actions {
-            let action_str = match action {
-                ActionName::PostCreate => "post_create",
-                ActionName::PostRun => "post_run",
-                ActionName::PostRebuild => "post_rebuild",
-                _ => continue,
-            };
-
             let action_obj = blueprint.actions.get(&action);
-            let description = action_obj
-                .map(|a| a.description.as_str())
-                .unwrap_or("Lifecycle action");
+            if action_obj.is_none() {
+                continue;
+            }
+            let action_obj = action_obj.unwrap();
+            let action_name: String = action.clone().into();
+            let action_type: String = action.clone().get_type().into();
+            let description = match &action_obj.description {
+                desc if desc.is_empty() => action_type.as_str(),
+                desc => desc.as_str(),
+            };
 
             // Format the services and commands in a readable wabacon
-            let services_commands = match action_obj {
-                Some(action_obj) => format_services_command(&action_obj.commands),
-                None => "None".to_string(),
-            };
+            let services_commands = format_services_command(&action_obj.commands);
 
             builder.push_record(vec![
-                &action_str.dimmed().to_string(),
-                "Lifecycle",
+                &action_name.dimmed().to_string(),
+                &action_type,
                 description,
                 &services_commands,
             ]);
@@ -153,7 +150,7 @@ pub async fn blueprint_info(
 
                     builder.push_record(vec![
                         &name.green().to_string(),
-                        "Custom",
+                        action.get_type().as_str(),
                         description,
                         &services_commands,
                     ]);

--- a/scottyctl/src/commands/blueprints.rs
+++ b/scottyctl/src/commands/blueprints.rs
@@ -146,7 +146,7 @@ pub async fn blueprint_info(
             match action {
                 ActionName::Custom(name) => {
                     let description = action_obj.description.as_str();
-                    let services_commands = format_services_command(&action_obj.commands);
+                    let services_commands = format_services_commands(&action_obj.commands);
 
                     builder.push_record(vec![
                         &name.green().to_string(),

--- a/scottyctl/src/commands/blueprints.rs
+++ b/scottyctl/src/commands/blueprints.rs
@@ -54,15 +54,12 @@ pub async fn blueprint_info(
         let blueprints: AppBlueprintList = serde_json::from_value(result)?;
 
         // Find the specified blueprint
-        let blueprint = blueprints.blueprints.get(&cmd.blueprint_name);
-        if blueprint.is_none() {
-            return Err(anyhow::anyhow!(
-                "Blueprint {} not found",
-                cmd.blueprint_name.yellow()
-            ));
-        }
-
-        let blueprint = blueprint.unwrap();
+        let blueprint = blueprints
+            .blueprints
+            .get(&cmd.blueprint_name)
+            .ok_or_else(|| {
+                anyhow::anyhow!("Blueprint {} not found", cmd.blueprint_name.yellow())
+            })?;
 
         // Format and display the blueprint info
         let mut output = String::new();

--- a/scottyctl/src/commands/blueprints.rs
+++ b/scottyctl/src/commands/blueprints.rs
@@ -117,20 +117,20 @@ pub async fn blueprint_info(
         use tabled::settings::Padding;
 
         // Add lifecycle actions
-        for action in lifecycle_actions {
-            let action_obj = blueprint.actions.get(&action);
+        for action in &lifecycle_actions {
+            let action_obj = blueprint.actions.get(action);
             if action_obj.is_none() {
                 continue;
             }
             let action_obj = action_obj.unwrap();
             let action_name: String = action.clone().into();
-            let action_type: String = action.clone().get_type().into();
+            let action_type: String = action.get_type().into();
             let description = match &action_obj.description {
                 desc if desc.is_empty() => action_type.as_str(),
                 desc => desc.as_str(),
             };
 
-            // Format the services and commands in a readable wabacon
+            // Format the services and commands in a readable way
             let services_commands = format_services_command(&action_obj.commands);
 
             builder.push_record(vec![

--- a/scottyctl/src/commands/blueprints.rs
+++ b/scottyctl/src/commands/blueprints.rs
@@ -1,10 +1,11 @@
+use owo_colors::OwoColorize;
 use tabled::{
     builder::Builder,
     settings::{object::Columns, Style, Width},
 };
 
-use crate::{api::get, context::AppContext};
-use scotty_core::settings::app_blueprint::AppBlueprintList;
+use crate::{api::get, cli::BlueprintInfoCommand, context::AppContext};
+use scotty_core::settings::app_blueprint::{ActionName, AppBlueprintList};
 
 pub async fn list_blueprints(context: &AppContext) -> anyhow::Result<()> {
     let ui = context.ui();
@@ -30,10 +31,173 @@ pub async fn list_blueprints(context: &AppContext) -> anyhow::Result<()> {
         table.with(Style::modern_rounded());
         table.modify(Columns::single(0), Width::wrap(15).keep_words(true));
         table.modify(Columns::single(1), Width::wrap(15).keep_words(true));
-        table.modify(Columns::single(3), Width::wrap(10).keep_words(true));
+        table.modify(Columns::single(2), Width::wrap(25).keep_words(true));
+        table.modify(Columns::single(3), Width::wrap(40).keep_words(true));
 
         ui.success("Got blueprint list!");
         Ok(table.to_string())
+    })
+    .await
+}
+
+pub async fn blueprint_info(
+    context: &AppContext,
+    cmd: &BlueprintInfoCommand,
+) -> anyhow::Result<()> {
+    let ui = context.ui();
+    ui.new_status_line(format!(
+        "Getting info for blueprint {}...",
+        cmd.blueprint_name.yellow()
+    ));
+    ui.run(async || {
+        let result = get(context.server(), "blueprints").await?;
+        let blueprints: AppBlueprintList = serde_json::from_value(result)?;
+
+        // Find the specified blueprint
+        let blueprint = blueprints.blueprints.get(&cmd.blueprint_name);
+        if blueprint.is_none() {
+            return Err(anyhow::anyhow!(
+                "Blueprint {} not found",
+                cmd.blueprint_name.yellow()
+            ));
+        }
+
+        let blueprint = blueprint.unwrap();
+
+        // Format and display the blueprint info
+        let mut output = String::new();
+        output.push_str(&format!("Blueprint: {}\n", cmd.blueprint_name.yellow()));
+        output.push_str(&format!("Name: {}\n", blueprint.name));
+        output.push_str(&format!("Description: {}\n", blueprint.description));
+        output.push_str(&format!(
+            "Required Services: {}\n",
+            blueprint.required_services.join(", ")
+        ));
+
+        // Display public services if any
+        if let Some(public_services) = &blueprint.public_services {
+            output.push_str("\nPublic Services:\n");
+            let mut builder = Builder::default();
+            builder.push_record(vec!["Service", "Port"]);
+            for (service, port) in public_services {
+                builder.push_record(vec![service, &port.to_string()]);
+            }
+            let table = builder.build().with(Style::modern_rounded()).to_string();
+            output.push_str(&format!("{}\n", table));
+        }
+
+        // Display actions
+        output.push_str("\nActions:\n");
+
+        // First standard lifecycle actions
+        let lifecycle_actions = vec![
+            ActionName::PostCreate,
+            ActionName::PostRun,
+            ActionName::PostRebuild,
+        ];
+
+        let mut builder = Builder::default();
+        builder.push_record(vec!["Action", "Type", "Description", "Services & Commands"]);
+
+        // Configure table settings for better readability
+        use tabled::settings::Padding;
+
+        // Add lifecycle actions
+        for action in lifecycle_actions {
+            let action_str = match action {
+                ActionName::PostCreate => "post_create",
+                ActionName::PostRun => "post_run",
+                ActionName::PostRebuild => "post_rebuild",
+                _ => continue,
+            };
+
+            let description = blueprint
+                .action_descriptions
+                .get(&action)
+                .map(|s| s.as_str())
+                .unwrap_or("Lifecycle action");
+
+            let services_map = blueprint.actions.get(&action);
+
+            // Format the services and commands in a readable way
+            let mut services_commands = String::new();
+            if let Some(service_commands) = services_map {
+                for (i, (service, commands)) in service_commands.iter().enumerate() {
+                    if i > 0 {
+                        services_commands.push_str("\n\n");
+                    }
+                    services_commands.push_str(&format!("{}:", service.blue().bold()));
+
+                    for cmd in commands {
+                        services_commands.push_str(&format!("\n  ▹ {}", cmd.dimmed()));
+                    }
+                }
+            } else {
+                services_commands = "None".to_string();
+            }
+
+            builder.push_record(vec![
+                &action_str.dimmed().to_string(),
+                "Lifecycle",
+                description,
+                &services_commands,
+            ]);
+        }
+
+        // Add custom actions
+        for (action, services) in &blueprint.actions {
+            match action {
+                ActionName::Custom(name) => {
+                    let description = blueprint
+                        .action_descriptions
+                        .get(action)
+                        .map(|s| s.as_str())
+                        .unwrap_or("Custom action");
+
+                    // Format the services and commands in a readable way
+                    let mut services_commands = String::new();
+                    for (i, (service, commands)) in services.iter().enumerate() {
+                        if i > 0 {
+                            services_commands.push_str("\n\n");
+                        }
+                        services_commands.push_str(&format!("{}:", service.blue().bold()));
+
+                        for cmd in commands {
+                            services_commands.push_str(&format!("\n  ▹ {}", cmd));
+                        }
+                    }
+
+                    builder.push_record(vec![
+                        &name.green().to_string(),
+                        "Custom",
+                        description,
+                        &services_commands,
+                    ]);
+                }
+                _ => continue, // Skip lifecycle actions already handled
+            }
+        }
+
+        let mut table = builder.build();
+        table
+            .with(Style::modern_rounded())
+            .with(Padding::new(1, 1, 0, 0));
+
+        output.push_str(&format!("{}\n", table));
+
+        // Add a note about how to run custom actions
+        output.push_str(&format!(
+            "\n{}: Custom actions can be executed with '{}'\n",
+            "Note".yellow().bold(),
+            "scottyctl app:action <app-name> <action-name>".green()
+        ));
+
+        ui.success(format!(
+            "Info for blueprint {} retrieved successfully",
+            cmd.blueprint_name.yellow()
+        ));
+
+        Ok(output)
     })
     .await
 }

--- a/scottyctl/src/main.rs
+++ b/scottyctl/src/main.rs
@@ -56,6 +56,9 @@ async fn main() -> anyhow::Result<()> {
             print_completions(cmd.shell, &mut cli_cmd);
         }
         Commands::BlueprintList => commands::blueprints::list_blueprints(&app_context).await?,
+        Commands::BlueprintInfo(cmd) => {
+            commands::blueprints::blueprint_info(&app_context, cmd).await?
+        }
         Commands::Test => commands::test::run_tests(&app_context).await?,
     }
     Ok(())

--- a/scottyctl/src/main.rs
+++ b/scottyctl/src/main.rs
@@ -46,6 +46,7 @@ async fn main() -> anyhow::Result<()> {
         Commands::Adopt(cmd) => commands::apps::adopt_app(&app_context, cmd).await?,
         Commands::Info(cmd) => commands::apps::info_app(&app_context, cmd).await?,
         Commands::Create(cmd) => commands::apps::create_app(&app_context, cmd).await?,
+        Commands::Action(cmd) => commands::apps::run_custom_action(&app_context, cmd).await?,
         Commands::NotifyAdd(cmd) => commands::notify::add_notification(&app_context, cmd).await?,
         Commands::NotifyRemove(cmd) => {
             commands::notify::remove_notification(&app_context, cmd).await?


### PR DESCRIPTION
Enable defining and running custom actions beyond standard lifecycle hooks. Users can now trigger these actions via the new API endpoint and CLI command. Blueprint files can define named actions that can be executed on demand.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for running custom actions on apps via a new API endpoint and CLI command.
  - Introduced CLI commands to trigger custom app actions and to display detailed blueprint information.
  - Added new named actions for app blueprints and improved action configuration flexibility.
  - Provided a new status check action for Nginx blueprints.
  - Enhanced blueprint details display with formatted output including action descriptions and commands.
  - Added notifications for completion of custom app actions.
  - Introduced a UI dropdown component to list and trigger custom app actions from the dashboard.
  - Integrated the custom actions dropdown into the app dashboard UI for supported app statuses.

- **Bug Fixes**
  - Cleaned up blueprint configurations by removing unnecessary output statements.

- **Documentation**
  - Enhanced OpenAPI documentation to include the new custom action API endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->