### PR TITLE
fix: Add SecureJson wrapper to mask sensitive env vars in API responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1111,12 +1111,12 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
- "futures-util",
+ "futures-core",
  "http",
  "http-body",
  "pin-project-lite",
@@ -2555,6 +2555,7 @@ dependencies = [
  "clokwerk",
  "config",
  "futures-util",
+ "http-body-util",
  "include_dir",
  "init-tracing-opentelemetry",
  "maplit",
@@ -2602,6 +2603,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yml",
+ "tempfile",
  "tokio",
  "tracing",
  "url",

--- a/scotty-core/Cargo.toml
+++ b/scotty-core/Cargo.toml
@@ -27,6 +27,7 @@ uuid.workspace = true
 bollard.workspace = true
 deunicode.workspace = true
 url.workspace = true
+tempfile = "3.20.0"
 
 [dev-dependencies.cargo-husky]
 version = "1"

--- a/scotty-core/Cargo.toml
+++ b/scotty-core/Cargo.toml
@@ -27,6 +27,8 @@ uuid.workspace = true
 bollard.workspace = true
 deunicode.workspace = true
 url.workspace = true
+
+[dev-dependencies]
 tempfile = "3.20.0"
 
 [dev-dependencies.cargo-husky]

--- a/scotty-core/src/apps/app_data/settings.rs
+++ b/scotty-core/src/apps/app_data/settings.rs
@@ -20,7 +20,7 @@ use crate::{
 use super::super::create_app_request::CustomDomainMapping;
 use super::{service::ServicePortMapping, ttl::AppTtl};
 
-#[derive(Debug, Deserialize, Clone, ToSchema, ToResponse)]
+#[derive(Debug, Deserialize, Serialize, Clone, ToSchema, ToResponse)]
 pub struct AppSettings {
     pub public_services: Vec<ServicePortMapping>,
     pub domain: String,
@@ -34,34 +34,6 @@ pub struct AppSettings {
     pub app_blueprint: Option<String>,
     #[serde(default)]
     pub notify: HashSet<NotificationReceiver>,
-}
-
-// Implement Serialize manually with redaction for sensitive environment variables
-impl Serialize for AppSettings {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        use crate::utils::sensitive_data::mask_sensitive_env_map;
-        use serde::ser::SerializeStruct;
-
-        // Create masked environment variables using the utility function
-        let masked_env = mask_sensitive_env_map(&self.environment);
-
-        // Serialize with the struct serializer
-        let mut state = serializer.serialize_struct("AppSettings", 10)?;
-        state.serialize_field("public_services", &self.public_services)?;
-        state.serialize_field("domain", &self.domain)?;
-        state.serialize_field("time_to_live", &self.time_to_live)?;
-        state.serialize_field("destroy_on_ttl", &self.destroy_on_ttl)?;
-        state.serialize_field("basic_auth", &self.basic_auth)?;
-        state.serialize_field("disallow_robots", &self.disallow_robots)?;
-        state.serialize_field("environment", &masked_env)?;
-        state.serialize_field("registry", &self.registry)?;
-        state.serialize_field("app_blueprint", &self.app_blueprint)?;
-        state.serialize_field("notify", &self.notify)?;
-        state.end()
-    }
 }
 
 impl Default for AppSettings {
@@ -175,5 +147,93 @@ impl AppSettings {
             info!("No settings file found at {}", &settings_path.display());
             Ok(None)
         }
+    }
+
+    #[cfg(test)]
+    pub fn to_file(&self, settings_path: &Path) -> anyhow::Result<()> {
+        let yaml = serde_yml::to_string(self)
+            .map_err(|e| anyhow::anyhow!("Failed to serialize settings to YAML: {}", e))?;
+
+        std::fs::write(settings_path, yaml).map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to write settings to {}: {}",
+                settings_path.display(),
+                e
+            )
+        })?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils::sensitive_data::{is_sensitive, mask_sensitive_env_map};
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_environment_vars_not_masked_in_yaml_file() {
+        // Create AppSettings with sensitive environment variables
+        let mut env_vars = HashMap::new();
+        env_vars.insert("API_KEY".to_string(), "secret-api-key-12345".to_string());
+        env_vars.insert(
+            "DATABASE_URL".to_string(),
+            "postgres://user:password@localhost/db".to_string(),
+        );
+        env_vars.insert("NORMAL_VAR".to_string(), "not-sensitive".to_string());
+
+        let settings = AppSettings {
+            public_services: vec![],
+            domain: "test.example.com".to_string(),
+            time_to_live: AppTtl::Days(7),
+            destroy_on_ttl: false,
+            basic_auth: None,
+            disallow_robots: true,
+            environment: env_vars,
+            registry: None,
+            app_blueprint: None,
+            notify: HashSet::new(),
+        };
+
+        // Create a temporary directory for the test
+        let temp_dir = tempdir().expect("Failed to create temp dir");
+        let settings_path = temp_dir.path().join(".scotty.yml");
+
+        // Save settings to file
+        settings
+            .to_file(&settings_path)
+            .expect("Failed to save settings");
+
+        // Read the settings back from the file
+        let loaded_settings = AppSettings::from_file(&settings_path)
+            .expect("Failed to load settings")
+            .expect("Settings should exist");
+
+        // Verify sensitive environment variables are not masked
+        assert_eq!(
+            loaded_settings.environment.get("API_KEY").unwrap(),
+            "secret-api-key-12345"
+        );
+        assert_eq!(
+            loaded_settings.environment.get("DATABASE_URL").unwrap(),
+            "postgres://user:password@localhost/db"
+        );
+        assert_eq!(
+            loaded_settings.environment.get("NORMAL_VAR").unwrap(),
+            "not-sensitive"
+        );
+
+        // Verify that if we were to mask them, they would be different
+        let masked_env = mask_sensitive_env_map(&settings.environment);
+        assert_ne!(masked_env.get("API_KEY").unwrap(), "secret-api-key-12345");
+        assert_ne!(
+            masked_env.get("DATABASE_URL").unwrap(),
+            "postgres://user:password@localhost/db"
+        );
+
+        // Verify that the sensitive detection is working correctly
+        assert!(is_sensitive("API_KEY"));
+        assert!(!is_sensitive("NORMAL_VAR"));
     }
 }

--- a/scotty/Cargo.toml
+++ b/scotty/Cargo.toml
@@ -50,5 +50,6 @@ tokio-stream.workspace = true
 clokwerk.workspace = true
 bcrypt.workspace = true
 utoipa-axum.workspace = true
+http-body-util = "0.1.3"
 [package.metadata.release]
 pre-release-hook = ["echo", "skipping"]

--- a/scotty/src/api/handlers/apps/create.rs
+++ b/scotty/src/api/handlers/apps/create.rs
@@ -1,4 +1,7 @@
-use crate::{api::error::AppError, app_state::SharedAppState, docker::create_app::create_app};
+use crate::{
+    api::error::AppError, api::secure_response::SecureJson, app_state::SharedAppState,
+    docker::create_app::create_app,
+};
 use axum::{debug_handler, extract::State, response::IntoResponse, Json};
 use base64::prelude::*;
 use scotty_core::{
@@ -66,7 +69,7 @@ pub async fn create_app_handler(
     let settings = settings.apply_custom_domains(&payload.custom_domains)?;
 
     match create_app(state, &payload.app_name, &settings, &file_list).await {
-        Ok(app_data) => Ok(Json(app_data)),
+        Ok(app_data) => Ok(SecureJson(app_data)),
         Err(e) => {
             error!("App create failed with: {:?}", e);
             Err(AppError::from(e))

--- a/scotty/src/api/handlers/apps/list.rs
+++ b/scotty/src/api/handlers/apps/list.rs
@@ -1,7 +1,7 @@
-use axum::{debug_handler, extract::State, response::IntoResponse, Json};
+use axum::{debug_handler, extract::State, response::IntoResponse};
 use scotty_core::apps::shared_app_list::AppDataVec;
 
-use crate::{api::error::AppError, app_state::SharedAppState};
+use crate::{api::error::AppError, api::secure_response::SecureJson, app_state::SharedAppState};
 #[utoipa::path(
     get,
     path = "/api/v1/apps/list",
@@ -18,5 +18,5 @@ pub async fn list_apps_handler(
     State(state): State<SharedAppState>,
 ) -> Result<impl IntoResponse, AppError> {
     let apps = state.apps.get_apps().await;
-    Ok(Json(apps))
+    Ok(SecureJson(apps))
 }

--- a/scotty/src/api/handlers/apps/notify.rs
+++ b/scotty/src/api/handlers/apps/notify.rs
@@ -4,7 +4,7 @@ use scotty_core::{
     notification_types::{AddNotificationRequest, NotificationReceiver, RemoveNotificationRequest},
 };
 
-use crate::{api::error::AppError, app_state::SharedAppState};
+use crate::{api::error::AppError, api::secure_response::SecureJson, app_state::SharedAppState};
 
 #[utoipa::path(
     post,
@@ -60,7 +60,7 @@ pub async fn add_notification_handler(
     app.save_settings().await?;
     state.apps.update_app(app.clone()).await?;
 
-    Ok(Json(app))
+    Ok(SecureJson(app))
 }
 
 #[utoipa::path(
@@ -96,5 +96,5 @@ pub async fn remove_notification_handler(
     app.save_settings().await?;
     state.apps.update_app(app.clone()).await?;
 
-    Ok(Json(app))
+    Ok(SecureJson(app))
 }

--- a/scotty/src/api/handlers/apps/run.rs
+++ b/scotty/src/api/handlers/apps/run.rs
@@ -1,7 +1,7 @@
+use crate::api::secure_response::SecureJson;
 use axum::{
     extract::{Path, State},
     response::IntoResponse,
-    Json,
 };
 use scotty_core::{
     apps::app_data::AppData, tasks::running_app_context::RunningAppContext, utils::slugify::slugify,
@@ -42,7 +42,7 @@ pub async fn run_app_handler(
     }
     let app_data = app_data.unwrap();
     let app_data = run_app(state, &app_data).await?;
-    Ok(Json(app_data))
+    Ok(SecureJson(app_data))
 }
 
 #[utoipa::path(
@@ -67,7 +67,7 @@ pub async fn stop_app_handler(
     }
     let app_data = app_data.unwrap();
     let app_data = stop_app(state, &app_data).await?;
-    Ok(Json(app_data))
+    Ok(SecureJson(app_data))
 }
 
 #[utoipa::path(
@@ -92,7 +92,7 @@ pub async fn purge_app_handler(
     }
     let app_data = app_data.unwrap();
     let app_data = purge_app(state, &app_data).await?;
-    Ok(Json(app_data))
+    Ok(SecureJson(app_data))
 }
 
 #[utoipa::path(
@@ -116,7 +116,7 @@ pub async fn info_app_handler(
         return Err(AppError::AppNotFound(app_id.clone()));
     }
     let app_data = app_data.unwrap();
-    Ok(Json(app_data))
+    Ok(SecureJson(app_data))
 }
 
 #[utoipa::path(
@@ -141,7 +141,7 @@ pub async fn rebuild_app_handler(
     }
     let app_data = app_data.unwrap();
     let app_data = rebuild_app(state, &app_data).await?;
-    Ok(Json(app_data))
+    Ok(SecureJson(app_data))
 }
 
 #[utoipa::path(
@@ -170,7 +170,7 @@ pub async fn destroy_app_handler(
         return Err(AppError::CantDestroyUnmanagedApp(app_id.clone()));
     }
     let app_data = destroy_app(state, &app_data).await?;
-    Ok(Json(app_data))
+    Ok(SecureJson(app_data))
 }
 
 #[utoipa::path(
@@ -205,5 +205,5 @@ pub async fn adopt_app_handler(
     let app_data = app_data.create_settings_from_runtime(&environment).await?;
     state.apps.update_app(app_data.clone()).await?;
 
-    Ok(Json(app_data))
+    Ok(SecureJson(app_data))
 }

--- a/scotty/src/api/mod.rs
+++ b/scotty/src/api/mod.rs
@@ -4,4 +4,8 @@ pub mod handlers;
 pub mod message;
 pub mod message_handler;
 pub mod router;
+pub mod secure_response;
 pub mod ws;
+
+#[cfg(test)]
+mod secure_response_test;

--- a/scotty/src/api/secure_response.rs
+++ b/scotty/src/api/secure_response.rs
@@ -1,0 +1,78 @@
+use axum::{response::IntoResponse, Json};
+use scotty_core::{
+    apps::{
+        app_data::{AppData, AppSettings},
+        shared_app_list::AppDataVec,
+    },
+    tasks::running_app_context::RunningAppContext,
+    utils::sensitive_data::mask_sensitive_env_map,
+};
+
+/// A wrapper around Axum's Json response type that masks sensitive environment variables
+/// in API responses containing AppData, AppDataVec, or AppSettings.
+///
+/// This ensures sensitive data is only masked when responding through the API,
+/// and not in other parts of the application where the raw values are needed.
+///
+/// Note: SecureJson should only be used with AppData, AppDataVec, and AppSettings types.
+/// For other types, use Json directly.
+#[derive(Debug, Clone)]
+pub struct SecureJson<T>(pub T);
+
+/// Implementation for AppData
+impl IntoResponse for SecureJson<AppData> {
+    fn into_response(self) -> axum::response::Response {
+        let mut app_data = self.0;
+
+        // Mask sensitive environment variables if settings exist
+        if let Some(settings) = app_data.settings.as_mut() {
+            let masked_env = mask_sensitive_env_map(&settings.environment);
+            settings.environment = masked_env;
+        }
+
+        Json(app_data).into_response()
+    }
+}
+
+/// Implementation for AppDataVec (list of apps)
+impl IntoResponse for SecureJson<AppDataVec> {
+    fn into_response(self) -> axum::response::Response {
+        let mut apps_vec = self.0;
+
+        // Process each app in the vector
+        for app in &mut apps_vec.apps {
+            if let Some(settings) = app.settings.as_mut() {
+                let masked_env = mask_sensitive_env_map(&settings.environment);
+                settings.environment = masked_env;
+            }
+        }
+
+        Json(apps_vec).into_response()
+    }
+}
+
+/// Implementation for AppSettings directly
+impl IntoResponse for SecureJson<AppSettings> {
+    fn into_response(self) -> axum::response::Response {
+        let mut settings = self.0;
+        let masked_env = mask_sensitive_env_map(&settings.environment);
+        settings.environment = masked_env;
+
+        Json(settings).into_response()
+    }
+}
+
+/// Implementation for RunningAppContext
+impl IntoResponse for SecureJson<RunningAppContext> {
+    fn into_response(self) -> axum::response::Response {
+        let mut running_context = self.0;
+
+        // Mask sensitive environment variables if settings exist
+        if let Some(settings) = running_context.app_data.settings.as_mut() {
+            let masked_env = mask_sensitive_env_map(&settings.environment);
+            settings.environment = masked_env;
+        }
+
+        Json(running_context).into_response()
+    }
+}

--- a/scotty/src/api/secure_response_test.rs
+++ b/scotty/src/api/secure_response_test.rs
@@ -1,0 +1,315 @@
+use std::collections::{HashMap, HashSet};
+
+use axum::{http::StatusCode, response::IntoResponse, Json};
+use chrono::DateTime;
+use http_body_util::BodyExt;
+use scotty_core::{
+    apps::{
+        app_data::{AppData, AppSettings, AppStatus, AppTtl},
+        shared_app_list::AppDataVec,
+    },
+    tasks::{
+        running_app_context::RunningAppContext,
+        task_details::{State, TaskDetails},
+    },
+};
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use crate::api::secure_response::SecureJson;
+
+// Helper functions for test data creation
+fn create_app_settings_with_env_vars(env_vars: HashMap<String, String>) -> AppSettings {
+    AppSettings {
+        public_services: vec![],
+        domain: "test.example.com".to_string(),
+        time_to_live: AppTtl::Days(7),
+        destroy_on_ttl: false,
+        basic_auth: None,
+        disallow_robots: true,
+        environment: env_vars,
+        registry: None,
+        app_blueprint: None,
+        notify: HashSet::new(),
+    }
+}
+
+fn create_test_app_data(settings: AppSettings) -> AppData {
+    AppData {
+        name: "test-app".to_string(),
+        settings: Some(settings),
+        services: vec![],
+        docker_compose_path: "/path/to/docker-compose.yml".to_string(),
+        root_directory: "/path/to/app".to_string(),
+        status: AppStatus::Running,
+        last_checked: None,
+    }
+}
+
+// Helper function to extract the JSON body from an Axum response
+async fn extract_json_body<T: IntoResponse>(response: T) -> Value {
+    let response = response.into_response();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.into_body();
+    let bytes = BodyExt::collect(body)
+        .await
+        .expect("Failed to collect body")
+        .to_bytes();
+
+    serde_json::from_slice(&bytes).expect("Failed to parse JSON body")
+}
+
+#[tokio::test]
+async fn test_secure_json_masks_app_settings_env_vars() {
+    // Create AppSettings with sensitive environment variables
+    let mut env_vars = HashMap::new();
+    env_vars.insert("API_KEY".to_string(), "secret-api-key-12345".to_string());
+    env_vars.insert(
+        "DATABASE_URL".to_string(),
+        "postgres://user:password@localhost/db".to_string(),
+    );
+    env_vars.insert("NORMAL_VAR".to_string(), "not-sensitive".to_string());
+
+    let settings = create_app_settings_with_env_vars(env_vars.clone());
+
+    // Create regular Json response
+    let regular_json = Json(settings.clone());
+    let regular_json_body = extract_json_body(regular_json).await;
+
+    // Create SecureJson response
+    let secure_json = SecureJson(settings.clone());
+    let secure_json_body = extract_json_body(secure_json).await;
+
+    // Verify regular JSON contains unmasked env vars
+    assert_eq!(
+        regular_json_body["environment"]["API_KEY"],
+        json!("secret-api-key-12345")
+    );
+    assert_eq!(
+        regular_json_body["environment"]["DATABASE_URL"],
+        json!("postgres://user:password@localhost/db")
+    );
+
+    // Verify SecureJson response contains masked env vars
+    assert_ne!(
+        secure_json_body["environment"]["API_KEY"],
+        json!("secret-api-key-12345")
+    );
+    assert_ne!(
+        secure_json_body["environment"]["DATABASE_URL"],
+        json!("postgres://user:password@localhost/db")
+    );
+
+    // Verify non-sensitive vars are unchanged
+    assert_eq!(
+        secure_json_body["environment"]["NORMAL_VAR"],
+        json!("not-sensitive")
+    );
+
+    // Verify that other fields are unchanged
+    assert_eq!(secure_json_body["domain"], json!("test.example.com"));
+
+    // Verify masking pattern follows expected format
+    let masked_api_key = secure_json_body["environment"]["API_KEY"].as_str().unwrap();
+    assert!(masked_api_key.starts_with("*****"));
+    assert!(masked_api_key.ends_with("45"));
+}
+
+#[tokio::test]
+async fn test_secure_json_masks_app_data_env_vars() {
+    // Create AppData with sensitive environment variables
+    let mut env_vars = HashMap::new();
+    env_vars.insert("API_KEY".to_string(), "secret-api-key-12345".to_string());
+    env_vars.insert("DB_PASSWORD".to_string(), "supersecretpassword".to_string());
+
+    let settings = create_app_settings_with_env_vars(env_vars.clone());
+    let app_data = create_test_app_data(settings);
+
+    // Create regular Json response
+    let regular_json = Json(app_data.clone());
+    let regular_json_body = extract_json_body(regular_json).await;
+
+    // Create SecureJson response
+    let secure_json = SecureJson(app_data.clone());
+    let secure_json_body = extract_json_body(secure_json).await;
+
+    // Verify regular JSON contains unmasked sensitive values
+    assert_eq!(
+        regular_json_body["settings"]["environment"]["API_KEY"],
+        json!("secret-api-key-12345")
+    );
+    assert_eq!(
+        regular_json_body["settings"]["environment"]["DB_PASSWORD"],
+        json!("supersecretpassword")
+    );
+
+    // Verify SecureJson response contains masked sensitive values
+    assert_ne!(
+        secure_json_body["settings"]["environment"]["API_KEY"],
+        json!("secret-api-key-12345")
+    );
+    assert_ne!(
+        secure_json_body["settings"]["environment"]["DB_PASSWORD"],
+        json!("supersecretpassword")
+    );
+
+    // Verify that other fields are unchanged
+    assert_eq!(secure_json_body["name"], json!("test-app"));
+    assert_eq!(secure_json_body["status"], json!("Running"));
+
+    // Verify masking pattern follows expected format
+    let masked_password = secure_json_body["settings"]["environment"]["DB_PASSWORD"]
+        .as_str()
+        .unwrap();
+    assert!(masked_password.starts_with("*****"));
+    assert!(masked_password.ends_with("word"));
+}
+
+#[tokio::test]
+async fn test_secure_json_masks_app_data_vec_env_vars() {
+    // Create AppDataVec with sensitive environment variables
+    let mut env_vars = HashMap::new();
+    env_vars.insert("API_KEY".to_string(), "secret-api-key-12345".to_string());
+    env_vars.insert("AUTH_TOKEN".to_string(), "bearer-token-secret".to_string());
+
+    let settings = create_app_settings_with_env_vars(env_vars.clone());
+    let app_data = create_test_app_data(settings);
+
+    // Create an AppDataVec with our app
+    let app_data_vec = AppDataVec {
+        apps: vec![app_data.clone()],
+    };
+
+    // Create regular Json response
+    let regular_json = Json(app_data_vec);
+    let regular_json_body = extract_json_body(regular_json).await;
+
+    // Create SecureJson response - create a new instance with the same app data
+    let secure_json = SecureJson(AppDataVec {
+        apps: vec![app_data.clone()],
+    });
+    let secure_json_body = extract_json_body(secure_json).await;
+
+    // Verify regular JSON contains unmasked sensitive values
+    assert_eq!(
+        regular_json_body["apps"][0]["settings"]["environment"]["API_KEY"],
+        json!("secret-api-key-12345")
+    );
+    assert_eq!(
+        regular_json_body["apps"][0]["settings"]["environment"]["AUTH_TOKEN"],
+        json!("bearer-token-secret")
+    );
+
+    // Verify SecureJson response contains masked sensitive values
+    assert_ne!(
+        secure_json_body["apps"][0]["settings"]["environment"]["API_KEY"],
+        json!("secret-api-key-12345")
+    );
+    assert_ne!(
+        secure_json_body["apps"][0]["settings"]["environment"]["AUTH_TOKEN"],
+        json!("bearer-token-secret")
+    );
+
+    // Verify that the masked values follow our expected masking pattern
+    let masked_api_key = secure_json_body["apps"][0]["settings"]["environment"]["API_KEY"]
+        .as_str()
+        .unwrap();
+    assert!(masked_api_key.starts_with("*****")); // Should start with asterisks
+    assert!(masked_api_key.ends_with("45")); // Should end with last 2-4 chars
+
+    let masked_token = secure_json_body["apps"][0]["settings"]["environment"]["AUTH_TOKEN"]
+        .as_str()
+        .unwrap();
+    assert!(masked_token.starts_with("*****")); // Should start with asterisks
+    assert!(masked_token.ends_with("cret")); // Should end with last 2-4 chars
+}
+
+#[tokio::test]
+async fn test_secure_json_masks_running_app_context_env_vars() {
+    // Create environment variables with sensitive data
+    let mut env_vars = HashMap::new();
+    env_vars.insert("API_KEY".to_string(), "very-sensitive-key-456".to_string());
+    env_vars.insert(
+        "SECRET_TOKEN".to_string(),
+        "super-secret-token-123".to_string(),
+    );
+    env_vars.insert("DEBUG_MODE".to_string(), "enabled".to_string()); // Not sensitive
+
+    // Create settings with sensitive environment variables
+    let settings = create_app_settings_with_env_vars(env_vars.clone());
+
+    // Create app data with the settings
+    let app_data = create_test_app_data(settings);
+
+    // Create task details
+    let task_details = TaskDetails {
+        id: Uuid::new_v4(),
+        command: "test-command".to_string(),
+        state: State::Finished,
+        stdout: "Command output".to_string(),
+        stderr: "".to_string(),
+        start_time: DateTime::from(std::time::SystemTime::now()),
+        finish_time: Some(DateTime::from(std::time::SystemTime::now())),
+        last_exit_code: Some(0),
+        app_name: Some("test-app".to_string()),
+    };
+
+    // Create RunningAppContext
+    let running_context = RunningAppContext {
+        task: task_details.clone(),
+        app_data: app_data.clone(),
+    };
+
+    // Create regular Json response
+    let regular_json = Json(running_context);
+    let regular_json_body = extract_json_body(regular_json).await;
+
+    // Create SecureJson response with a new instance
+    let secure_json = SecureJson(RunningAppContext {
+        task: task_details,
+        app_data: app_data.clone(),
+    });
+    let secure_json_body = extract_json_body(secure_json).await;
+
+    // Verify regular JSON contains unmasked sensitive values
+    assert_eq!(
+        regular_json_body["app_data"]["settings"]["environment"]["API_KEY"],
+        json!("very-sensitive-key-456")
+    );
+    assert_eq!(
+        regular_json_body["app_data"]["settings"]["environment"]["SECRET_TOKEN"],
+        json!("super-secret-token-123")
+    );
+
+    // Verify SecureJson response contains masked sensitive values
+    assert_ne!(
+        secure_json_body["app_data"]["settings"]["environment"]["API_KEY"],
+        json!("very-sensitive-key-456")
+    );
+    assert_ne!(
+        secure_json_body["app_data"]["settings"]["environment"]["SECRET_TOKEN"],
+        json!("super-secret-token-123")
+    );
+
+    // Verify non-sensitive values are unchanged
+    assert_eq!(
+        secure_json_body["app_data"]["settings"]["environment"]["DEBUG_MODE"],
+        json!("enabled")
+    );
+
+    // Verify task details are unchanged (only checking the state as ID is dynamically generated)
+    assert_eq!(secure_json_body["task"]["state"], json!("Finished"));
+    assert_eq!(secure_json_body["task"]["command"], json!("test-command"));
+
+    // Verify app name and other fields are unchanged
+    assert_eq!(secure_json_body["app_data"]["name"], json!("test-app"));
+    assert_eq!(secure_json_body["app_data"]["status"], json!("Running"));
+
+    // Verify masking pattern follows expected format
+    let masked_token = secure_json_body["app_data"]["settings"]["environment"]["SECRET_TOKEN"]
+        .as_str()
+        .unwrap();
+    assert!(masked_token.starts_with("*****")); // Should start with asterisks
+    assert!(masked_token.ends_with("123")); // Should end with last few chars
+}


### PR DESCRIPTION
The previous implementation redacted sensitive environment variables during serialization, which masked them in both API responses and stored YAML files. This change keeps sensitive data intact in storage while masking it only in API responses.

Fixes #341

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - API responses for application data now automatically mask sensitive environment variables, enhancing data privacy when accessing app details, settings, and status.
- **Bug Fixes**
  - Serialization of application settings to files now includes full environment variable values, ensuring accurate persistence and restoration.
- **Tests**
  - Added comprehensive tests to verify that sensitive environment variables are properly masked in API responses while remaining intact in storage and internal processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->