### PR TITLE
feat: Add Traefik middleware support and examples

### DIFF
--- a/apps/simple_nginx/.scotty.yml
+++ b/apps/simple_nginx/.scotty.yml
@@ -6,6 +6,9 @@ domain: simple_nginx.ddev.site
 time_to_live: !Days 7
 basic_auth: null
 disallow_robots: true
+middlewares:
+  - rate-limit
+  - cors-headers
 environment:
   FOO: BAR
   FOOX: hjfaklsjghfkljhsaflkgjhasflgkhjasflkgjhasfklgjhasklfghjsalkjghasflgkjhasfklgjhfsgalkfgjhaslkfgjhaslfkgjhasfglkjahsfglksajfghaskfgjhasfglkjhaslkjghaslkfgjhasflgkjhasfglkjhagsflkj

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -1,28 +1,30 @@
 api:
-  bind_address: "127.0.0.1:21342"
-  access_token: hello-world
+    bind_address: "127.0.0.1:21342"
+    access_token: hello-world
 telemetry: None
 apps:
-  domain_suffix: "ddev.site"
-  use_tls: false
-  root_folder: "./apps" # Path to the folder where the apps are stored
+    domain_suffix: "ddev.site"
+    use_tls: false
+    root_folder: "./apps" # Path to the folder where the apps are stored
 docker:
-  connection: local # local, socket or http, see bollard docs
+    connection: local # local, socket or http, see bollard docs
 load_balancer_type: Traefik #HaproxyConfig or Traefik
 traefik:
-  use_tls: false
+    use_tls: false
+    allowed_middlewares:
+        - "test-middleware"
 haproxy:
-  use_tls: false
+    use_tls: false
 notification_services:
-  chat_factorial_io:
-    type: mattermost
-    host: https://chat.factorial.io
-    hook_id: xxx # Override with SCOTTY__NOTIFICATION_SERVICES__CHAT_FACTORIAL_IO__HOOK_ID
-  webhook-test:
-    type: webhook
-    method: post
-    url: https://wh66e463ada4ac505d47.free.beeceptor.com
-  source_factorial_io:
-    type: gitlab
-    host: https://source.factorial.io
-    token: xxx # Override with SCOTTY__NOTIFICATION_SERVICES__SOURCE_FACTORIAL_IO__TOKEN
+    chat_factorial_io:
+        type: mattermost
+        host: https://chat.factorial.io
+        hook_id: xxx # Override with SCOTTY__NOTIFICATION_SERVICES__CHAT_FACTORIAL_IO__HOOK_ID
+    webhook-test:
+        type: webhook
+        method: post
+        url: https://wh66e463ada4ac505d47.free.beeceptor.com
+    source_factorial_io:
+        type: gitlab
+        host: https://source.factorial.io
+        token: xxx # Override with SCOTTY__NOTIFICATION_SERVICES__SOURCE_FACTORIAL_IO__TOKEN

--- a/docs/content/architecture.md
+++ b/docs/content/architecture.md
@@ -150,7 +150,7 @@ networks:
 ```
 
 The traefik implementation also supports custom middlewares. Please declare them
-in the `config` directory. Then you can refer to the listed middlewared in the
+in the `config` directory. Then you can refer to the listed middlewares in the
 `app:create`-command and the `--middleware`-option.
 
 ### [Haproxy-Config](https://github.com/factorial-io/haproxy-config)

--- a/docs/content/architecture.md
+++ b/docs/content/architecture.md
@@ -149,6 +149,10 @@ networks:
     external: true
 ```
 
+The traefik implementation also supports custom middlewares. Please declare them
+in the `config` directory. Then you can refer to the listed middlewared in the
+`app:create`-command and the `--middleware`-option.
+
 ### [Haproxy-Config](https://github.com/factorial-io/haproxy-config)
 
 Scotty supports the legacy setup called haproxy-config. It will create the

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -84,7 +84,8 @@ scottyctl --server <SERVER> --access-token <TOKEN> app:create <APP> --folder <FO
   [--custom-domain <DOMAIN:SERVICE>] [--custom-domain <DOMAIN:SERVICE> ...] \
   [--env <KEY=VALUE>] [--env <KEY=VALUE> ...] \
   [--env-file <FILE>] \
-  [--registry <REGISTRY>]
+  [--registry <REGISTRY>] \
+  [--middleware <MIDDLEWARE>] [--middleware <MIDDLEWARE> ...]
 ```
 
 This command will create a new app on the server. The `--folder` argument is
@@ -129,6 +130,12 @@ The server needs to be configured accordingly.
 You can use a private registry for the images with the `--registry` argument. The
 argument should contain the name of the registry. The server needs to be
 configured accordingly.
+
+You can add middleware to the app with the `--middleware` argument. The argument
+should contain the name of the middleware. Middleware must be in the allow-list in
+the server configuration before they can be used. You can specify multiple
+middleware by using the `--middleware` argument multiple times. (This is only
+supported for traefik)
 
 ### Some examples:
 

--- a/examples/middleware-examples/.scotty.yml
+++ b/examples/middleware-examples/.scotty.yml
@@ -2,12 +2,12 @@
 # This configuration shows how to use custom Traefik middlewares
 
 public_services:
-  - service: web
-    port: 80
-  - service: api
-    port: 3000
-    domains:
-      - api.my-app.example.com
+    - service: web
+      port: 80
+    - service: api
+      port: 3000
+      domains:
+          - api.my-app.example.com
 
 domain: my-app.example.com
 time_to_live: !Days 7
@@ -17,23 +17,22 @@ destroy_on_ttl: false
 basic_auth: null
 
 # Keep robots protection enabled
-disallow_robots: true
+disallow_robots: false
 
 # Custom middlewares applied to all public services
 # These are applied AFTER built-in middlewares (robots in this case)
 middlewares:
-  - rate-limit
-  - security-headers
-  - cors-policy
-  - compress
+    - rate-limit
+    - security-headers
+    - cors-policy
+    - compress
 
 environment:
-  NODE_ENV: production
-  API_BASE_URL: https://api.my-app.example.com
-  DATABASE_URL: "{{ .Env.DATABASE_URL }}"
-  
+    NODE_ENV: production
+    API_BASE_URL: https://api.my-app.example.com
+
 registry: null
 app_blueprint: null
 
 notify:
-  - Log
+    - Log

--- a/examples/middleware-examples/.scotty.yml
+++ b/examples/middleware-examples/.scotty.yml
@@ -1,0 +1,39 @@
+# Example .scotty.yml demonstrating the new middlewares feature
+# This configuration shows how to use custom Traefik middlewares
+
+public_services:
+  - service: web
+    port: 80
+  - service: api
+    port: 3000
+    domains:
+      - api.my-app.example.com
+
+domain: my-app.example.com
+time_to_live: !Days 7
+destroy_on_ttl: false
+
+# Basic auth is disabled to showcase custom middlewares only
+basic_auth: null
+
+# Keep robots protection enabled
+disallow_robots: true
+
+# Custom middlewares applied to all public services
+# These are applied AFTER built-in middlewares (robots in this case)
+middlewares:
+  - rate-limit
+  - security-headers
+  - cors-policy
+  - compress
+
+environment:
+  NODE_ENV: production
+  API_BASE_URL: https://api.my-app.example.com
+  DATABASE_URL: "{{ .Env.DATABASE_URL }}"
+  
+registry: null
+app_blueprint: null
+
+notify:
+  - Log

--- a/examples/middleware-examples/README.md
+++ b/examples/middleware-examples/README.md
@@ -1,0 +1,190 @@
+# Middleware Examples
+
+This directory contains examples of how to use the new `middlewares` feature in Scotty with Traefik.
+
+## Overview
+
+The `middlewares` field in your `.scotty.yml` file allows you to specify custom Traefik middlewares that will be applied to your services. These middlewares are applied in addition to any built-in middlewares (basic auth and robots protection).
+
+## Middleware Order
+
+Middlewares are applied in the following order:
+
+1. Built-in basic auth middleware (if `basic_auth` is configured)
+2. Built-in robots middleware (if `disallow_robots` is true)
+3. Custom middlewares (in the order specified in the `middlewares` array)
+
+## Examples
+
+### Example 1: Rate Limiting and CORS
+
+```yaml
+# .scotty.yml
+public_services:
+  - service: web
+    port: 80
+domain: my-app.example.com
+time_to_live: !Days 7
+basic_auth: null
+disallow_robots: true
+middlewares:
+  - rate-limit
+  - cors-headers
+environment:
+  NODE_ENV: production
+```
+
+**Generated Traefik labels:**
+```
+traefik.http.routers.web--my-app-0.middlewares: web--my-app--robots,rate-limit,cors-headers
+```
+
+### Example 2: Authentication + Security Headers
+
+```yaml
+# .scotty.yml
+public_services:
+  - service: api
+    port: 3000
+domain: api.example.com
+time_to_live: !Days 30
+basic_auth:
+  - "admin"
+  - "secretpassword"
+disallow_robots: true
+middlewares:
+  - security-headers
+  - api-rate-limit
+environment:
+  API_KEY: "{{ .Env.API_KEY }}"
+```
+
+**Generated Traefik labels:**
+```
+traefik.http.routers.api--my-app-0.middlewares: api--my-app--basic-auth,api--my-app--robots,security-headers,api-rate-limit
+```
+
+### Example 3: Custom Middlewares Only
+
+```yaml
+# .scotty.yml
+public_services:
+  - service: frontend
+    port: 8080
+domain: frontend.example.com
+time_to_live: !Days 7
+basic_auth: null
+disallow_robots: false  # No built-in middlewares
+middlewares:
+  - compress
+  - custom-headers
+  - redirect-scheme
+environment:
+  REACT_APP_API_URL: "https://api.example.com"
+```
+
+**Generated Traefik labels:**
+```
+traefik.http.routers.frontend--my-app-0.middlewares: compress,custom-headers,redirect-scheme
+```
+
+### Example 4: Multiple Services with Different Middlewares
+
+```yaml
+# .scotty.yml
+public_services:
+  - service: web
+    port: 80
+  - service: api
+    port: 3000
+domain: my-app.example.com
+time_to_live: !Days 14
+basic_auth: null
+disallow_robots: true
+middlewares:
+  - global-rate-limit
+  - security-headers
+environment:
+  DATABASE_URL: "postgres://user:pass@db:5432/myapp"
+```
+
+**Generated Traefik labels:**
+```
+# For web service:
+traefik.http.routers.web--my-app-0.middlewares: web--my-app--robots,global-rate-limit,security-headers
+
+# For api service:
+traefik.http.routers.api--my-app-0.middlewares: api--my-app--robots,global-rate-limit,security-headers
+```
+
+## Common Middleware Use Cases
+
+### Rate Limiting
+- `rate-limit`: Basic rate limiting
+- `api-rate-limit`: API-specific rate limiting
+- `ddos-protection`: Advanced DDoS protection
+
+### Security
+- `security-headers`: Add security headers (HSTS, CSP, etc.)
+- `cors-headers`: Configure CORS policies
+- `ip-whitelist`: Restrict access by IP address
+
+### Performance
+- `compress`: Enable gzip compression
+- `cache-headers`: Set appropriate cache headers
+- `cdn-headers`: Configure CDN-specific headers
+
+### Redirects & Rewrites
+- `redirect-scheme`: HTTP to HTTPS redirects
+- `www-redirect`: WWW to non-WWW redirects
+- `path-rewrite`: URL path rewriting
+
+## Prerequisites
+
+Before using custom middlewares, you need to:
+
+1. Define the middlewares in your Traefik configuration
+2. Ensure the middleware names match exactly what you specify in `middlewares`
+3. Make sure your Traefik instance can access the middleware definitions
+
+## Traefik Middleware Configuration Example
+
+Here's how you might define some of these middlewares in your Traefik configuration:
+
+```yaml
+# traefik.yml or docker-compose.yml
+http:
+  middlewares:
+    rate-limit:
+      rateLimit:
+        burst: 100
+        average: 50
+    
+    security-headers:
+      headers:
+        customRequestHeaders:
+          X-Forwarded-Proto: "https"
+        customResponseHeaders:
+          X-Frame-Options: "DENY"
+          X-Content-Type-Options: "nosniff"
+    
+    cors-headers:
+      headers:
+        accessControlAllowMethods:
+          - "GET"
+          - "POST"
+          - "PUT"
+          - "DELETE"
+        accessControlAllowOriginList:
+          - "https://example.com"
+        accessControlMaxAge: 100
+        addVaryHeader: true
+```
+
+## Notes
+
+- Middleware names are case-sensitive
+- The order of middlewares in the array matters
+- Built-in middlewares (basic auth, robots) are always applied before custom middlewares
+- If a middleware doesn't exist in Traefik, the service may fail to start
+- You can use the same middleware across multiple apps by referencing the same name

--- a/frontend/src/routes/dashboard/[slug]/+page.svelte
+++ b/frontend/src/routes/dashboard/[slug]/+page.svelte
@@ -31,7 +31,9 @@
 
 	async function handleClick(action: string) {
 		if (action === 'Destroy') {
-			if (!confirm(`Are you sure you want to destroy the app ${data.name} and all its data?`)) {
+			if (
+				!confirm(`Are you sure you want to destroy the app ${data.name} and all its data?`)
+			) {
 				return;
 			}
 		}

--- a/frontend/src/routes/dashboard/[slug]/+page.svelte
+++ b/frontend/src/routes/dashboard/[slug]/+page.svelte
@@ -31,9 +31,7 @@
 
 	async function handleClick(action: string) {
 		if (action === 'Destroy') {
-			if (
-				!confirm(`Are you sure you want to destroy the app ${data.name} and all its data?`)
-			) {
+			if (!confirm(`Are you sure you want to destroy the app ${data.name} and all its data?`)) {
 				return;
 			}
 		}
@@ -154,6 +152,10 @@
 			<tr>
 				<td class="text-gray-500 align-top"><strong>Time to live</strong></td>
 				<td class="align-top">{format_ttl(data.settings.time_to_live)}</td>
+			</tr>
+			<tr>
+				<td class="text-gray-500 align-top"><strong>Middlewares</strong></td>
+				<td class="align-top">{format_value(data.settings.middlewares?.join(', '))}</td>
 			</tr>
 			<tr>
 				<td class="text-gray-500 align-top"><strong>Environment</strong></td>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -32,6 +32,7 @@ export interface AppSettings {
 	app_blueprint: string;
 	basic_auth: [string, string] | null;
 	environment: Map<string, string> | null;
+	middlewares: string[];
 }
 
 export interface App {

--- a/scotty-core/src/apps/app_data/settings.rs
+++ b/scotty-core/src/apps/app_data/settings.rs
@@ -34,6 +34,8 @@ pub struct AppSettings {
     pub app_blueprint: Option<String>,
     #[serde(default)]
     pub notify: HashSet<NotificationReceiver>,
+    #[serde(default)]
+    pub middlewares: Vec<String>,
 }
 
 impl Default for AppSettings {
@@ -49,6 +51,7 @@ impl Default for AppSettings {
             registry: None,
             app_blueprint: None,
             notify: HashSet::new(),
+            middlewares: Vec::new(),
         }
     }
 }
@@ -187,13 +190,9 @@ mod tests {
             public_services: vec![],
             domain: "test.example.com".to_string(),
             time_to_live: AppTtl::Days(7),
-            destroy_on_ttl: false,
-            basic_auth: None,
             disallow_robots: true,
             environment: env_vars,
-            registry: None,
-            app_blueprint: None,
-            notify: HashSet::new(),
+            ..Default::default()
         };
 
         // Create a temporary directory for the test

--- a/scotty-core/src/settings/loadbalancer.rs
+++ b/scotty-core/src/settings/loadbalancer.rs
@@ -2,26 +2,33 @@
 
 use serde::Deserialize;
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
 pub enum LoadBalancerType {
     HaproxyConfig,
     Traefik,
 }
 
-#[derive(Debug, Deserialize, Clone)]
-#[allow(unused)]
+#[derive(Debug, Deserialize, Clone, Default)]
 pub struct TraefikSettings {
     pub use_tls: bool,
     pub network: String,
     pub certresolver: Option<String>,
+    #[serde(default)]
+    pub allowed_middlewares: Vec<String>,
 }
 
 impl TraefikSettings {
-    pub fn new(use_tls: bool, network: String, certresolver: Option<String>) -> Self {
+    pub fn new(
+        use_tls: bool,
+        network: String,
+        certresolver: Option<String>,
+        allowed_middlewares: Vec<String>,
+    ) -> Self {
         Self {
             use_tls,
             network,
             certresolver,
+            allowed_middlewares,
         }
     }
 }

--- a/scotty/src/api/error.rs
+++ b/scotty/src/api/error.rs
@@ -72,6 +72,9 @@ pub enum AppError {
 
     #[error("Cant adopt app {0} with existing settings, app can already be controlled by scotty!")]
     CantAdoptAppWithExistingSettings(String),
+
+    #[error("Middleware not allowed: {0}")]
+    MiddlewareNotAllowed(String),
 }
 impl AppError {
     fn get_error_msg(&self) -> (axum::http::StatusCode, String) {
@@ -81,6 +84,7 @@ impl AppError {
             AppError::InternalServerError(_) => StatusCode::INTERNAL_SERVER_ERROR,
             AppError::AppNotFound(_) => StatusCode::NOT_FOUND,
             AppError::TaskNotFound(_) => StatusCode::NOT_FOUND,
+            AppError::MiddlewareNotAllowed(_) => StatusCode::BAD_REQUEST,
             _ => StatusCode::INTERNAL_SERVER_ERROR,
         };
 

--- a/scotty/src/api/secure_response_test.rs
+++ b/scotty/src/api/secure_response_test.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use axum::{http::StatusCode, response::IntoResponse, Json};
 use chrono::DateTime;
@@ -28,9 +28,7 @@ fn create_app_settings_with_env_vars(env_vars: HashMap<String, String>) -> AppSe
         basic_auth: None,
         disallow_robots: true,
         environment: env_vars,
-        registry: None,
-        app_blueprint: None,
-        notify: HashSet::new(),
+        ..Default::default()
     }
 }
 

--- a/scotty/src/docker/loadbalancer/traefik.rs
+++ b/scotty/src/docker/loadbalancer/traefik.rs
@@ -151,6 +151,12 @@ impl LoadBalancerImpl for TraefikLoadBalancer {
 
                 middlewares.push(middleware_name.clone());
             }
+
+            // Add custom middlewares from settings
+            for middleware in &settings.middlewares {
+                middlewares.push(middleware.clone());
+            }
+
             // Connect the middleware to the router
             for (idx, _domain) in domains.iter().enumerate() {
                 labels.insert(
@@ -193,7 +199,7 @@ mod tests {
     #[test]
     fn test_traefik_get_docker_compose_override() {
         let global_settings = Settings {
-            traefik: TraefikSettings::new(true, "proxy".into(), Some("myresolver".into())),
+            traefik: TraefikSettings::new(true, "proxy".into(), Some("myresolver".into()), vec![]),
             ..Default::default()
         };
 
@@ -210,6 +216,10 @@ mod tests {
                 "FOO".to_string() => "BAR".to_string(),
                 "API_KEY".to_string() => "1234".to_string(),
             },
+            middlewares: vec![
+                "custom-middleware-1".to_string(),
+                "custom-middleware-2".to_string(),
+            ],
             ..Default::default()
         };
 
@@ -267,7 +277,7 @@ mod tests {
             labels
                 .get("traefik.http.routers.web--myapp-0.middlewares")
                 .unwrap(),
-            "web--myapp--basic-auth,web--myapp--robots"
+            "web--myapp--basic-auth,web--myapp--robots,custom-middleware-1,custom-middleware-2"
         );
 
         // check environment.

--- a/scotty/src/settings/config.rs
+++ b/scotty/src/settings/config.rs
@@ -63,9 +63,8 @@ impl Default for Settings {
             },
             load_balancer_type: LoadBalancerType::Traefik,
             traefik: TraefikSettings {
-                use_tls: false,
                 network: "proxy".to_string(),
-                certresolver: None,
+                ..Default::default()
             },
             haproxy: HaproxyConfigSettings { use_tls: false },
             onepassword: HashMap::new(),

--- a/scottyctl/src/cli.rs
+++ b/scottyctl/src/cli.rs
@@ -174,6 +174,10 @@ pub struct CreateCommand {
         help = "Allow search engines to index the app"
     )]
     pub allow_robots: bool,
+
+    /// Custom Traefik middlewares to apply to the app, can be specified multiple times
+    #[arg(long, value_name = "MIDDLEWARE")]
+    pub middleware: Vec<String>,
 }
 
 pub fn print_completions<G: clap_complete::Generator>(gen: G, cmd: &mut clap::Command) {

--- a/scottyctl/src/commands/apps.rs
+++ b/scottyctl/src/commands/apps.rs
@@ -259,6 +259,7 @@ pub async fn create_app(context: &AppContext, cmd: &CreateCommand) -> anyhow::Re
                 time_to_live: cmd.ttl.clone(),
                 disallow_robots: !cmd.allow_robots,
                 destroy_on_ttl: cmd.destroy_on_ttl,
+                middlewares: cmd.middleware.clone(),
                 ..Default::default()
             },
             files: file_list,


### PR DESCRIPTION
The commit adds middleware configuration capability to Scotty apps, complete with examples and documentation. It includes:

- New `middlewares` field in app settings
- Traefik integration for custom middleware support
- Comprehensive middleware examples and docs
- Tests for middleware functionality
- New option for passing middlewared for the `app:create`-command
- Validation of middlewares against a list of allowed middlewares in the traefik config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for specifying custom Traefik middlewares when creating apps, both via configuration files and the CLI.
  - Middleware usage is now validated against an allow-list in the server configuration for enhanced security.
  - The dashboard now displays the list of middlewares applied to each app.

- **Documentation**
  - Updated and expanded documentation to explain middleware configuration, usage examples, CLI options, and prerequisites.
  - Added new example files and guides illustrating middleware setup and best practices.

- **Bug Fixes**
  - Improved configuration file indentation for better readability and consistency.

- **Style**
  - Simplified code and configuration initialization for clarity and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->