### PR TITLE
fix: sanitize service names in autogenerated environment variables

### DIFF
--- a/scotty-core/src/apps/app_data/data.rs
+++ b/scotty-core/src/apps/app_data/data.rs
@@ -4,7 +4,7 @@ use tracing::info;
 use utoipa::{ToResponse, ToSchema};
 
 use crate::notification_types::NotificationReceiver;
-use crate::utils::{secret::SecretHashMap, slugify::slugify};
+use crate::utils::{format::sanitize_env_var_name, secret::SecretHashMap, slugify::slugify};
 
 use super::container::ContainerState;
 use super::settings::AppSettings;
@@ -148,7 +148,10 @@ impl AppData {
         for service in &self.services {
             let urls = service.get_urls();
             if !urls.is_empty() {
-                let name = format!("SCOTTY__PUBLIC_URL__{}", service.service.to_uppercase());
+                let name = format!(
+                    "SCOTTY__PUBLIC_URL__{}",
+                    sanitize_env_var_name(&service.service)
+                );
                 environment.insert(name, urls[0].to_string());
             }
         }

--- a/scotty-core/src/utils/format.rs
+++ b/scotty-core/src/utils/format.rs
@@ -42,3 +42,54 @@ pub fn format_bytes(bytes: usize) -> String {
         format!("{bytes} B")
     }
 }
+
+/// Sanitizes a string to be used as an environment variable name.
+/// Replaces hyphens and periods with underscores and converts to uppercase.
+///
+/// Docker Compose service names can contain [a-zA-Z0-9\._\-] characters,
+/// but environment variable names can only contain [a-zA-Z0-9_].
+///
+/// # Examples
+///
+/// ```
+/// use scotty_core::utils::format::sanitize_env_var_name;
+///
+/// assert_eq!(sanitize_env_var_name("my-service"), "MY_SERVICE");
+/// assert_eq!(sanitize_env_var_name("my.service"), "MY_SERVICE");
+/// assert_eq!(sanitize_env_var_name("my-service.v2"), "MY_SERVICE_V2");
+/// assert_eq!(sanitize_env_var_name("simple_service"), "SIMPLE_SERVICE");
+/// assert_eq!(sanitize_env_var_name("web"), "WEB");
+/// ```
+pub fn sanitize_env_var_name(name: &str) -> String {
+    name.replace(['-', '.'], "_").to_uppercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sanitize_env_var_name() {
+        assert_eq!(sanitize_env_var_name("my-service"), "MY_SERVICE");
+        assert_eq!(sanitize_env_var_name("my.service"), "MY_SERVICE");
+        assert_eq!(sanitize_env_var_name("my-service.v2"), "MY_SERVICE_V2");
+        assert_eq!(sanitize_env_var_name("simple_service"), "SIMPLE_SERVICE");
+        assert_eq!(sanitize_env_var_name("web"), "WEB");
+        assert_eq!(
+            sanitize_env_var_name("multi-word-service"),
+            "MULTI_WORD_SERVICE"
+        );
+        assert_eq!(
+            sanitize_env_var_name("service-with-many-hyphens"),
+            "SERVICE_WITH_MANY_HYPHENS"
+        );
+        assert_eq!(
+            sanitize_env_var_name("service.with.dots"),
+            "SERVICE_WITH_DOTS"
+        );
+        assert_eq!(
+            sanitize_env_var_name("mixed-service.v1_test"),
+            "MIXED_SERVICE_V1_TEST"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
Fixes issue #509 where autogenerated environment variables for service names containing hyphens or periods were invalid.

## Problem
Service names from docker-compose can contain `[a-zA-Z0-9\._\-]` characters, but environment variable names can only contain `[a-zA-Z0-9_]`. When Scotty autogenerates environment variables like `SCOTTY__PUBLIC_URL__<SERVICE_NAME>`, service names with hyphens or periods resulted in invalid environment variable names.

## Solution
- Added `sanitize_env_var_name()` utility function in `scotty-core/src/utils/format.rs`
- Function replaces hyphens and periods with underscores and converts to uppercase
- Updated `augment_environment()` in `scotty-core/src/apps/app_data/data.rs` to use the sanitization function
- Added comprehensive tests

## Test Plan
- All existing tests pass
- Added unit tests for `sanitize_env_var_name()` covering:
  - Service names with hyphens: `my-service` → `MY_SERVICE`
  - Service names with periods: `my.service` → `MY_SERVICE`
  - Mixed characters: `my-service.v2` → `MY_SERVICE_V2`
  - Underscores preserved: `simple_service` → `SIMPLE_SERVICE`
- Doctests verify the function behavior

Fixes #509