### PR TITLE
feat: add ASCII art logo with version and copyright

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3425,6 +3425,7 @@ dependencies = [
  "deunicode",
  "flate2",
  "futures-util",
+ "owo-colors",
  "readonly",
  "reqwest 0.12.24",
  "scotty-types",

--- a/scotty-core/Cargo.toml
+++ b/scotty-core/Cargo.toml
@@ -43,6 +43,7 @@ secrecy.workspace = true
 zeroize.workspace = true
 flate2.workspace = true
 walkdir.workspace = true
+owo-colors.workspace = true
 
 axum = { workspace = true }
 clap = { workspace = true, optional = true }

--- a/scotty-core/src/lib.rs
+++ b/scotty-core/src/lib.rs
@@ -3,6 +3,7 @@ pub mod api;
 pub mod apps;
 pub mod auth;
 pub mod http;
+pub mod logo;
 pub mod notification_types;
 pub mod output;
 pub mod settings;

--- a/scotty-core/src/logo.rs
+++ b/scotty-core/src/logo.rs
@@ -1,0 +1,64 @@
+use owo_colors::OwoColorize;
+
+/// RGB color representation
+struct RgbColor {
+    r: u8,
+    g: u8,
+    b: u8,
+}
+
+// Logo color - #005FA3 (blue)
+const LOGO_COLOR: RgbColor = RgbColor {
+    r: 0x00,
+    g: 0x5F,
+    b: 0xA3,
+};
+
+// Text color for version and copyright - #D1481A (orange-red)
+const TEXT_COLOR: RgbColor = RgbColor {
+    r: 0xD1,
+    g: 0x48,
+    b: 0x1A,
+};
+
+/// Print the scotty logo with version and copyright information
+///
+/// The logo is displayed in color #005FA3 (blue) and the version/copyright
+/// text in color #D1481A (orange-red), aligned to the right.
+pub fn print_logo() {
+    let version = env!("CARGO_PKG_VERSION");
+
+    // Lines of the ASCII art logo
+    let line1 = "                   ██    ██         ";
+    let line2 = "  ████ ████ ████ ████  ████   ██  ██";
+    let line3 = "████   ██   ████   ████  ████ ██████";
+    let line4 = "                                ████";
+
+    // Info text
+    let version_text = format!("   scotty v{}", version);
+    let copyright_text = "   Made with ❤️ by factorial.io";
+
+    // Print newline before logo
+    println!();
+
+    // Print the logo with colored text
+    println!(
+        "{}",
+        line1.truecolor(LOGO_COLOR.r, LOGO_COLOR.g, LOGO_COLOR.b)
+    );
+    println!(
+        "{}{}",
+        line2.truecolor(LOGO_COLOR.r, LOGO_COLOR.g, LOGO_COLOR.b),
+        version_text.truecolor(TEXT_COLOR.r, TEXT_COLOR.g, TEXT_COLOR.b)
+    );
+    println!(
+        "{}{}",
+        line3.truecolor(LOGO_COLOR.r, LOGO_COLOR.g, LOGO_COLOR.b),
+        copyright_text.truecolor(TEXT_COLOR.r, TEXT_COLOR.g, TEXT_COLOR.b)
+    );
+    println!(
+        "{}",
+        line4.truecolor(LOGO_COLOR.r, LOGO_COLOR.g, LOGO_COLOR.b)
+    );
+    println!();
+}

--- a/scotty/src/main.rs
+++ b/scotty/src/main.rs
@@ -18,6 +18,7 @@ mod utils;
 use docker::setup::setup_docker_integration;
 use http::setup_http_server;
 use scotty_core::settings::api_server::AuthMode;
+use std::io::IsTerminal;
 use tokio::time::sleep;
 use tracing::{info, warn};
 
@@ -48,6 +49,11 @@ async fn main() -> anyhow::Result<()> {
     // Environment variables always take precedence over .env files
     dotenvy::from_filename(".env.local").ok();
     dotenvy::dotenv().ok();
+
+    // Print logo if running in a terminal (before CLI parsing so --help shows it)
+    if std::io::stdout().is_terminal() {
+        scotty_core::logo::print_logo();
+    }
 
     let cli = Cli::parse();
 

--- a/scottyctl/src/main.rs
+++ b/scottyctl/src/main.rs
@@ -12,12 +12,18 @@ use cli::print_completions;
 use cli::{Cli, Commands};
 use context::{AppContext, ServerSettings};
 use preflight::PreflightChecker;
+use std::io::IsTerminal;
 use tracing::info;
 use tracing_subscriber::{prelude::*, EnvFilter};
 use utils::tracing_layer::UiLayer;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    // Print logo if running in a terminal (before CLI parsing so --help shows it)
+    if std::io::stdout().is_terminal() {
+        scotty_core::logo::print_logo();
+    }
+
     let cli = Cli::parse();
 
     // Create server settings from CLI parameters


### PR DESCRIPTION
## Summary
- Added ASCII art logo module in `scotty-core` with configurable RGB colors
- Logo displays in blue (#005FA3), version and copyright text in orange-red (#D1481A)
- Shows "Made with ❤️ by factorial.io" message
- Logo prints before CLI parsing to show on `--help`
- Only displays when stdout is a terminal (not when piped or redirected)

## Changes
- **scotty-core/src/logo.rs**: New logo module with `print_logo()` function
- **scotty-core/Cargo.toml**: Added `owo-colors` dependency
- **scotty/src/main.rs**: Print logo before CLI parsing
- **scottyctl/src/main.rs**: Print logo before CLI parsing

## Test plan
- [x] Build succeeds for both `scotty` and `scottyctl`
- [x] All tests pass
- [x] Logo displays when running `scotty --help`
- [x] Logo displays when running `scottyctl --help`
- [x] Logo displays when starting scotty server
- [x] Logo displays when running scottyctl commands
- [x] Logo does not display when output is piped