### PR TITLE
Add HEAD support to Homebrew formula

### DIFF
--- a/packaging/scottyctl.rb.tpl
+++ b/packaging/scottyctl.rb.tpl
@@ -26,7 +26,7 @@ class Scottyctl < Formula
 
   def install
     if build.head?
-      system "cargo", "install", "--path", ".", "--bin", "scottyctl", "--root", prefix
+      system "cargo", "install", "--path", "scottyctl", "--bin", "scottyctl", "--root", prefix
     else
       bin.install "scottyctl"
     end


### PR DESCRIPTION
This PR adds HEAD support to the Homebrew formula template, allowing users to install the latest development version from the `next` branch using:

```bash
brew install --HEAD scottyctl
```

The changes include:
- Added `head` block pointing to the `next` branch
- Added Rust build dependency (required for HEAD builds)
- Updated `install` method to handle HEAD builds using `cargo install`