### PR TITLE
fix(haproxy): collapse nested if into match guard

### DIFF
--- a/scotty/src/docker/loadbalancer/haproxy.rs
+++ b/scotty/src/docker/loadbalancer/haproxy.rs
@@ -35,10 +35,8 @@ impl LoadBalancerImpl for HaproxyLoadBalancer {
                                 result.port = Some(port);
                             }
                         }
-                        "HTTPS_ONLY" => {
-                            if value.to_lowercase() == "true" || value == "1" {
-                                result.tls_enabled = true;
-                            }
+                        "HTTPS_ONLY" if value.to_lowercase() == "true" || value == "1" => {
+                            result.tls_enabled = true;
                         }
                         "HTTP_AUTH_USER" => {
                             result.basic_auth_user = Some(value.to_string());

--- a/scotty/src/docker/loadbalancer/haproxy.rs
+++ b/scotty/src/docker/loadbalancer/haproxy.rs
@@ -35,8 +35,8 @@ impl LoadBalancerImpl for HaproxyLoadBalancer {
                                 result.port = Some(port);
                             }
                         }
-                        "HTTPS_ONLY" if value.to_lowercase() == "true" || value == "1" => {
-                            result.tls_enabled = true;
+                        "HTTPS_ONLY" => {
+                            result.tls_enabled |= value.to_lowercase() == "true" || value == "1";
                         }
                         "HTTP_AUTH_USER" => {
                             result.basic_auth_user = Some(value.to_string());


### PR DESCRIPTION
Resolves clippy::collapsible_match warning introduced in Rust 1.95.0.

https://claude.ai/code/session_01TN5rWne9nVWSHXHUoFoNqo