### PR TITLE
ci: fix release-please for virtual workspace manifest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,7 +139,7 @@ Grafana: http://grafana.ddev.site (admin/admin) | Jaeger: http://jaeger.ddev.sit
 Uses [release-please](https://github.com/googleapis/release-please) (PR-driven, fully in CI). Do not manually bump versions or edit changelogs.
 
 - Write [conventional commits](https://www.conventionalcommits.org) (`feat:`, `fix:`, `feat!:`/`BREAKING CHANGE:` for majors). The commit type determines the version bump and the changelog section.
-- On every push to `main`, the `release-please` workflow maintains a standing **release PR** that bumps the shared workspace version (`[workspace.package].version`, `Cargo.lock`) and regenerates `CHANGELOG.md`.
+- On every push to `main`, the `release-please` workflow maintains a standing **release PR** that bumps the shared workspace version (`[workspace.package].version` in `Cargo.toml`) and regenerates `CHANGELOG.md`.
 - **Merging that release PR** is the release: release-please creates the `vX.Y.Z` tag + GitHub Release, then the same workflow uploads `scottyctl` binaries, bumps the Homebrew tap, and publishes the versioned Docker image.
 
 Config lives in `release-please-config.json` and `.release-please-manifest.json`. The pre-push hook via `cargo-husky` still enforces local quality checks.

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Use [conventional commits](https://www.conventionalcommits.org) on `main` (the s
 
 #### 2. Review the release PR
 
-On every push to `main`, the `release-please` GitHub Actions workflow opens (and keeps updating) a **release PR** titled `chore: release <version>`. It contains the version bump (`Cargo.toml`, `Cargo.lock`) and the regenerated `CHANGELOG.md`. Inspect this PR to preview exactly what will ship.
+On every push to `main`, the `release-please` GitHub Actions workflow opens (and keeps updating) a **release PR** titled `chore: release <version>`. It contains the version bump (`[workspace.package].version` in `Cargo.toml`) and the regenerated `CHANGELOG.md`. Inspect this PR to preview exactly what will ship.
 
 #### 3. Merge to ship
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,10 +1,9 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "release-type": "rust",
   "include-v-in-tag": true,
   "include-component-in-tag": false,
+  "bump-minor-pre-major": true,
   "separate-pull-requests": false,
-  "pull-request-title-pattern": "chore: release ${version}",
   "changelog-sections": [
     { "type": "feat", "section": "Features" },
     { "type": "fix", "section": "Bug Fixes" },
@@ -21,8 +20,17 @@
   ],
   "packages": {
     ".": {
+      "release-type": "simple",
       "package-name": "scotty",
-      "changelog-path": "CHANGELOG.md"
+      "pull-request-title-pattern": "chore${scope}: release ${version}",
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        {
+          "type": "toml",
+          "path": "Cargo.toml",
+          "jsonpath": "$.workspace.package.version"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
The release-please job failed on push to main with:

    Fetching scotty-core/Cargo.toml from branch main
    Error: release-please failed: value at path package.version is not tagged

The `rust` release-type auto-detects the `[workspace]` root and traverses
the member crates, expecting each to declare a concrete `package.version`
string. All member crates inherit the version via `version.workspace =
true`, which release-please's Rust updater cannot parse, so the run
aborted and no release PR was ever created.

Switch the root package to the `simple` release-type and bump the shared
`[workspace.package].version` in Cargo.toml directly via a `toml`
extra-file updater (jsonpath `$.workspace.package.version`). This is the
proven pattern for Rust virtual workspaces with a single inherited
version. Also:

- Set the PR title pattern to `chore${scope}: release ${version}` to
  clear the `pullRequestTitlePattern miss the part of` warnings.
- Add `bump-minor-pre-major` for sane 0.x bumping.
- Drop the inaccurate `Cargo.lock` mention from the docs (simple type
  only touches Cargo.toml + CHANGELOG.md; release builds do not use
  --locked, so the lockfile self-heals on build).