### PR TITLE
chore(deps): update rust crate bollard to 0.21.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,9 +318,9 @@ dependencies = [
 
 [[package]]
 name = "bollard"
-version = "0.20.2"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee04c4c84f1f811b017f2fbb7dd8815c976e7ca98593de9c1e2afad0f636bff4"
+checksum = "c9d0a013e3d3ee4edd61e779adf117944c08902d375f18630a0c5b8f95659734"
 dependencies = [
  "base64 0.22.1",
  "bollard-stubs",
@@ -356,9 +356,9 @@ dependencies = [
 
 [[package]]
 name = "bollard-stubs"
-version = "1.52.1-rc.29.1.3"
+version = "1.53.1-rc.29.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0a8ca8799131c1837d1282c3f81f31e76ceb0ce426e04a7fe1ccee3287c066"
+checksum = "ce412eb6f7096743011dc3cb5c674caeb24ced61d8c498fe07cf7998a4fea889"
 dependencies = [
  "chrono",
  "serde",
@@ -4640,7 +4640,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ license-file = "LICENSE"
 [workspace.dependencies]
 anyhow = "1.0.89"
 axum = { version = "0.8.0", default-features = false, features = ["http1", "http2", "tokio", "tower-log", "matched-path", "json", "ws", "macros"] }
-bollard = { version = "0.20.0", default-features = false, features = ["ssl", "chrono", "http", "pipe"] }
-bollard-stubs = "1.52.1-rc.29.1.3"
+bollard = { version = "0.21.0", default-features = false, features = ["ssl", "chrono", "http", "pipe"] }
+bollard-stubs = "1.53.1-rc.29.3.1"
 config = { version = "0.15.0", default-features = false, features = ["yaml", "toml"] }
 readonly = "0.2.12"
 serde = { version = "1.0.210", features = ["derive"] }

--- a/scotty-core/src/apps/app_data/container.rs
+++ b/scotty-core/src/apps/app_data/container.rs
@@ -15,6 +15,7 @@ pub enum ContainerStatus {
     Removing,
     Exited,
     Dead,
+    Stopping,
 }
 
 impl Display for ContainerStatus {
@@ -28,6 +29,7 @@ impl Display for ContainerStatus {
             ContainerStatus::Removing => write!(f, "removing"),
             ContainerStatus::Exited => write!(f, "exited"),
             ContainerStatus::Dead => write!(f, "dead"),
+            ContainerStatus::Stopping => write!(f, "stopping"),
         }
     }
 }
@@ -43,6 +45,7 @@ impl From<ContainerStateStatusEnum> for ContainerStatus {
             ContainerStateStatusEnum::REMOVING => ContainerStatus::Removing,
             ContainerStateStatusEnum::EXITED => ContainerStatus::Exited,
             ContainerStateStatusEnum::DEAD => ContainerStatus::Dead,
+            ContainerStateStatusEnum::STOPPING => ContainerStatus::Stopping,
         }
     }
 }


### PR DESCRIPTION
Bump bollard 0.20.0 -> 0.21.0 and the directly-depended bollard-stubs
1.52.1-rc.29.1.3 -> 1.53.1-rc.29.3.1 to a compatible release (bollard
0.21.0 requires bollard-stubs =1.53.1-rc.29.3.1, which the original
Renovate PR could not resolve, leaving Cargo.lock stale and CI red).

Regenerate Cargo.lock and handle the new ContainerStateStatusEnum::STOPPING
variant (added for Podman support in API 1.53) by adding a Stopping variant
to ContainerStatus, wiring it through Display and the From conversion.
Stopping is treated as not running, since it is a transitional state on
the way to exited.