### PR TITLE
fix(deps): sync Cargo.lock with workspace version and keep it synced on release

### DIFF
--- a/.beans/scotty-pulh--fix-docker-build-cargolock-out-of-sync-after-030-r.md
+++ b/.beans/scotty-pulh--fix-docker-build-cargolock-out-of-sync-after-030-r.md
@@ -1,0 +1,17 @@
+---
+# scotty-pulh
+title: 'Fix Docker build: Cargo.lock out of sync after 0.3.0 release'
+status: completed
+type: bug
+priority: high
+created_at: 2026-06-07T14:42:52Z
+updated_at: 2026-06-07T14:43:26Z
+---
+
+release-please bumped workspace version 0.2.9 to 0.3.0 in Cargo.toml but did not update Cargo.lock, breaking 'cargo run --locked' in the ts-generator Docker stage.
+
+## Summary of Changes
+
+Root cause: release-please commit b5d8967 bumped workspace version 0.2.9 to 0.3.0 in Cargo.toml but left Cargo.lock pinning the five local crates at 0.2.9. Docker ts-generator stage runs 'cargo run --locked' and refused the stale lock.
+
+Fix: ran 'cargo update -p scotty --precise 0.3.0' which bumped only the 5 workspace members in Cargo.lock. PR #823.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3092,7 +3092,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scotty"
-version = "0.2.9"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3161,7 +3161,7 @@ dependencies = [
 
 [[package]]
 name = "scotty-core"
-version = "0.2.9"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3196,14 +3196,14 @@ dependencies = [
 
 [[package]]
 name = "scotty-ts-generator"
-version = "0.2.9"
+version = "0.3.0"
 dependencies = [
  "scotty-types",
 ]
 
 [[package]]
 name = "scotty-types"
-version = "0.2.9"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "serde",
@@ -3215,7 +3215,7 @@ dependencies = [
 
 [[package]]
 name = "scottyctl"
-version = "0.2.9"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,18 +5,55 @@
   "bump-minor-pre-major": true,
   "separate-pull-requests": false,
   "changelog-sections": [
-    { "type": "feat", "section": "Features" },
-    { "type": "fix", "section": "Bug Fixes" },
-    { "type": "perf", "section": "Performance" },
-    { "type": "refactor", "section": "Refactor" },
-    { "type": "refac", "section": "Refactor" },
-    { "type": "doc", "section": "Documentation" },
-    { "type": "docs", "section": "Documentation" },
-    { "type": "style", "section": "Styling" },
-    { "type": "test", "section": "Testing" },
-    { "type": "ci", "section": "CI" },
-    { "type": "deps", "section": "Dependencies" },
-    { "type": "chore", "section": "Miscellaneous Tasks", "hidden": true }
+    {
+      "type": "feat",
+      "section": "Features"
+    },
+    {
+      "type": "fix",
+      "section": "Bug Fixes"
+    },
+    {
+      "type": "perf",
+      "section": "Performance"
+    },
+    {
+      "type": "refactor",
+      "section": "Refactor"
+    },
+    {
+      "type": "refac",
+      "section": "Refactor"
+    },
+    {
+      "type": "doc",
+      "section": "Documentation"
+    },
+    {
+      "type": "docs",
+      "section": "Documentation"
+    },
+    {
+      "type": "style",
+      "section": "Styling"
+    },
+    {
+      "type": "test",
+      "section": "Testing"
+    },
+    {
+      "type": "ci",
+      "section": "CI"
+    },
+    {
+      "type": "deps",
+      "section": "Dependencies"
+    },
+    {
+      "type": "chore",
+      "section": "Miscellaneous Tasks",
+      "hidden": true
+    }
   ],
   "packages": {
     ".": {
@@ -29,6 +66,11 @@
           "type": "toml",
           "path": "Cargo.toml",
           "jsonpath": "$.workspace.package.version"
+        },
+        {
+          "type": "toml",
+          "path": "Cargo.lock",
+          "jsonpath": "$.package[?(@.name.value==='scotty'||@.name.value==='scotty-core'||@.name.value==='scotty-ts-generator'||@.name.value==='scotty-types'||@.name.value==='scottyctl')].version"
         }
       ]
     }


### PR DESCRIPTION
## Problem

The `Build and Push Docker Image` workflow fails at the `ts-generator` stage:

```
error: cannot update the lock file /app/Cargo.lock because --locked was passed to prevent this
```

## Root cause

release-please's `simple` release-type only updates `Cargo.toml` (via the `extra-files` toml updater for `$.workspace.package.version`). It never touches `Cargo.lock`. So when the release commit `b5d8967` bumped the workspace version `0.2.9 → 0.3.0`, `Cargo.lock` kept pinning the five local crates at `0.2.9`. The Docker `ts-generator` stage runs `cargo run --locked`, which refuses the stale lock.

**This recurs on every release** — not a one-off.

## Fix

1. **Immediate:** bump the five workspace member entries in `Cargo.lock` to `0.3.0` (`cargo update -p scotty --precise 0.3.0`). No other deps change.
2. **Permanent:** add a `Cargo.lock` entry to `release-please-config.json`'s `extra-files` so future bumps update the lock automatically.

### Why the jsonpath filters on `@.name.value`

release-please parses TOML with a custom `TaggedTOMLParser` that wraps every scalar as `{value, start, end}` (to enable formatting-preserving edits). So in the filter, `@.name` is an object — the comparison must be against `@.name.value`. A naive `@.name=='scotty'` filter silently matches nothing ("No entries modified").

Verified by running release-please's actual `GenericToml` updater against the pre-release `Cargo.lock`: output is byte-identical to the manual fix in this PR.