### PR TITLE
ci: build docker image on pull requests to catch breakage before merge

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
       - next
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build:
-    if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') }}
     runs-on: ubuntu-latest
 
     steps:
@@ -18,20 +20,27 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
+      # Only authenticate when we intend to publish (push events). On pull
+      # requests we build without pushing, so no registry login is needed.
       - name: Login to GitHub Container Registry
+        if: ${{ github.event_name == 'push' }}
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # On push: build and publish tagged with the branch name.
+      # On pull_request: build only (push: false) to catch breakage before
+      # merge -- e.g. a Cargo.lock that drifted out of sync with Cargo.toml.
       - name: Build and push Docker image
         uses: docker/build-push-action@v7
         with:
           context: .
-          push: true
+          push: ${{ github.event_name == 'push' }}
           platforms: linux/amd64
-          tags: ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+          tags: ghcr.io/${{ github.repository }}:${{ github.event_name == 'push' && github.ref_name || format('pr-{0}', github.event.number) }}
 
       - name: Log out of GitHub Container Registry
+        if: ${{ github.event_name == 'push' }}
         run: docker logout ghcr.io


### PR DESCRIPTION
## Why

The Docker build only runs on pushes to `main`/`next`. So a broken image build only surfaces *after* a PR merges — exactly how the `Cargo.lock` drift in #823 slipped through: the release PR looked green, but its merge broke the published image.

## Change

Also trigger the Docker build on `pull_request` to `main`, with `push: false` (build-only validation, nothing published):

- Registry login + logout are skipped on PRs (only needed when publishing).
- `push` events are unchanged: still build and publish tagged with the branch name.

This gives every PR — including the standing release-please PR — a real Docker build as a gate before merge.