### PR TITLE
fix: give each app its own Traefik proxy network to avoid DNS collisions

### DIFF
--- a/config/default.yaml.example
+++ b/config/default.yaml.example
@@ -57,7 +57,8 @@ docker:
 load_balancer_type: Traefik  # Options: Traefik, HaproxyConfig
 
 traefik:
-    network: "proxy"
+    network: "proxy"            # base name; each app gets its own "<network>--<app>" network
+    container_name: "traefik"   # Traefik container scotty connects to each app network
     use_tls: true
     certresolver: "myresolver"
 

--- a/docs/content/architecture.md
+++ b/docs/content/architecture.md
@@ -89,6 +89,10 @@ Unsupported apps are docker-compose-based applications which need environment
 variables to interact with `docker-compose` or are exposing ports directly.
 Scotty won't touch these apps but will show them in the UI and CLI. You
 can use the cli-command `app:adopt` to make the app compatible with Scotty.
+Note that `app:adopt` only creates the Scotty settings so the app is
+recognized by Scotty; it does not apply the load balancer configuration. Run
+`app:rebuild` afterwards to write the `docker-compose.override.yml`, create the
+per-app proxy network, and get the app fully working behind Traefik.
 
 ### Blueprints
 

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -403,6 +403,14 @@ environment variables into the `.scotty.yml` file.
 After adopting an app, it is strongly advised to check the `.scotty.yml` file and
 remove any unnecessary information from it and double-check the configuration.
 
+> **Note:** `app:adopt` only creates the Scotty settings (`.scotty.yml`) so the
+> app is recognized and managed by Scotty. It does **not** apply the load
+> balancer configuration to the running app: it writes no
+> `docker-compose.override.yml`, does not create the per-app proxy network, and
+> does not connect Traefik. The app keeps running as-is. To get the app fully
+> wired into Scotty's Traefik integration (override file, per-app network,
+> Traefik routing), run `app:rebuild` after adopting it.
+
 ## Destroy an app
 
 ```shell

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -542,6 +542,7 @@ and Haproxy-config (deprecated).
 load_balancer_type: Traefik #HaproxyConfig or Traefik
 traefik:
   network: "proxy"
+  container_name: "traefik"
   use_tls: true
   certresolver: "myresolver"
 haproxy:
@@ -552,11 +553,23 @@ haproxy:
 
 #### Traefik
 
-* `network` The network to use for the communication between scotty and traefik.
-  The default is `proxy`. If you use a different network, make sure to create
-  the network before starting scotty.
-  Scotty will also add the network to all public services of your app when you
-  create or adopt an app, so traefik can access the public services of the app.
+To avoid Docker DNS name collisions across apps (every app that defines an
+`nginx` service would otherwise publish the same `nginx` alias onto one shared
+network), scotty gives **each app its own dedicated proxy network** instead of
+putting all apps on a single shared network. For an app named `myapp` and a
+base `network` of `proxy`, the per-app network is `proxy--myapp`. Scotty
+creates this network before starting the app, connects the Traefik container to
+it, and removes it again when the app is destroyed or purged. Public services
+are tagged with the `traefik.docker.network` label so Traefik knows which
+network to route over.
+
+* `network` The base name used to derive each app's dedicated proxy network
+  (`<network>--<app-name>`). The default is `proxy`. Scotty creates and tears
+  down these per-app networks automatically; you do not need to create them
+  yourself.
+* `container_name` The name (or id) of the running Traefik container that
+  scotty connects to each app's proxy network. The default is `traefik`. Set
+  this if your Traefik container runs under a different name.
 * `use_tls` If set to true, scotty will create the necessary labels for traefik
   to use tls. The default is true.
 * `certresolver` The certresolver to use for the tls-certificate. The

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -576,6 +576,14 @@ network to route over.
   certresolver must be configured in traefik. The default is `myresolver` shown
   also in the example `compose.yml` from the [installation-documentation](installation.md)
 
+> **Upgrading from a shared-network version:** apps created before this change
+> still have a `docker-compose.override.yml` that references the old shared
+> network. They keep running and routable on that network until you migrate
+> them — Scotty does not rewrite the override automatically. Run `app:rebuild`
+> on each existing app to regenerate the override onto its per-app network and
+> connect Traefik. A plain `app:run` does not rewrite the override, so rebuild
+> is the migration step.
+
 #### Haproxy-config
 
 * `use_tls` If set to true, scotty will create the necessary environment variables

--- a/docs/content/installation.md
+++ b/docs/content/installation.md
@@ -98,8 +98,12 @@ Otherwise docker-compose can't find the files, as docker-compose is executed
 inside the Scotty container but working on the host.
 
 We are using a dedicated network named `proxy` for the communication of
-`traefik ↔ scotty ↔ apps`. If you want to use a different network, do not
-forget to adapt the Scotty configuration accordingly.
+`traefik ↔ scotty` and as Traefik's default network. Each app that Scotty
+manages gets its own dedicated network derived from this name
+(`proxy--<app-name>`); Scotty creates it and connects Traefik to it
+automatically, so apps no longer share one network (which would make Docker
+DNS names collide across apps). If you want to use a different base network,
+do not forget to adapt the Scotty configuration accordingly.
 
 Do not forget to create the network with:
 

--- a/scotty-core/src/settings/loadbalancer.rs
+++ b/scotty-core/src/settings/loadbalancer.rs
@@ -46,13 +46,14 @@ impl TraefikSettings {
         network: String,
         certresolver: Option<String>,
         allowed_middlewares: Vec<String>,
+        container_name: String,
     ) -> Self {
         Self {
             use_tls,
             network,
             certresolver,
             allowed_middlewares,
-            container_name: default_traefik_container_name(),
+            container_name,
         }
     }
 }

--- a/scotty-core/src/settings/loadbalancer.rs
+++ b/scotty-core/src/settings/loadbalancer.rs
@@ -14,6 +14,12 @@ pub fn default_traefik_container_name() -> String {
     "traefik".to_string()
 }
 
+/// Default base network name. This is the base for each app's per-app proxy
+/// network (`<network>--<app>`); it must never be empty.
+pub fn default_traefik_network() -> String {
+    "proxy".to_string()
+}
+
 #[derive(Debug, Deserialize, Clone)]
 pub struct TraefikSettings {
     pub use_tls: bool,
@@ -32,7 +38,11 @@ impl Default for TraefikSettings {
     fn default() -> Self {
         Self {
             use_tls: false,
-            network: String::new(),
+            // Matches the documented default and what config.rs sets. Must be
+            // non-empty: it is the base for each app's proxy network
+            // (`<network>--<app>`), and an empty base would yield a Docker-invalid
+            // name beginning with `-`.
+            network: default_traefik_network(),
             certresolver: None,
             allowed_middlewares: Vec::new(),
             container_name: default_traefik_container_name(),

--- a/scotty-core/src/settings/loadbalancer.rs
+++ b/scotty-core/src/settings/loadbalancer.rs
@@ -8,13 +8,36 @@ pub enum LoadBalancerType {
     Traefik,
 }
 
-#[derive(Debug, Deserialize, Clone, Default)]
+/// Default name of the Traefik container that Scotty connects to each
+/// per-app proxy network. Used both as the serde default and the `Default` impl.
+pub fn default_traefik_container_name() -> String {
+    "traefik".to_string()
+}
+
+#[derive(Debug, Deserialize, Clone)]
 pub struct TraefikSettings {
     pub use_tls: bool,
     pub network: String,
     pub certresolver: Option<String>,
     #[serde(default)]
     pub allowed_middlewares: Vec<String>,
+    /// Name (or id) of the running Traefik container. Scotty connects this
+    /// container to each app's dedicated proxy network so it can route to the
+    /// app's public services without sharing a single global network.
+    #[serde(default = "default_traefik_container_name")]
+    pub container_name: String,
+}
+
+impl Default for TraefikSettings {
+    fn default() -> Self {
+        Self {
+            use_tls: false,
+            network: String::new(),
+            certresolver: None,
+            allowed_middlewares: Vec::new(),
+            container_name: default_traefik_container_name(),
+        }
+    }
 }
 
 impl TraefikSettings {
@@ -29,6 +52,7 @@ impl TraefikSettings {
             network,
             certresolver,
             allowed_middlewares,
+            container_name: default_traefik_container_name(),
         }
     }
 }

--- a/scotty/src/api/rest/handlers/apps/run.rs
+++ b/scotty/src/api/rest/handlers/apps/run.rs
@@ -175,6 +175,13 @@ pub async fn destroy_app_handler(
     Ok(SecureJson(app_data))
 }
 
+/// Adopts an existing (unsupported) app by creating its Scotty settings so the
+/// app is recognized and managed by Scotty.
+///
+/// This only writes the `.scotty.yml` settings derived from the running app and
+/// registers it; it does NOT run a state machine. No `docker-compose.override.yml`
+/// is written, no per-app proxy network is created, and Traefik is not connected.
+/// Run `rebuild_app` afterwards to fully wire the app into the load balancer.
 #[utoipa::path(
     get,
     path = "/api/v1/authenticated/apps/adopt/{app_id}",

--- a/scotty/src/docker/create_app.rs
+++ b/scotty/src/docker/create_app.rs
@@ -21,6 +21,7 @@ use super::rebuild_app::rebuild_app_prepare;
 use super::state_machine_handlers::context::Context;
 use super::state_machine_handlers::create_directory_handler::CreateDirectoryHandler;
 use super::state_machine_handlers::create_load_balancer_config::CreateLoadBalancerConfig;
+use super::state_machine_handlers::network_handler::EnsureAppNetworkHandler;
 use super::state_machine_handlers::run_post_actions_handler::RunPostActionsHandler;
 use super::state_machine_handlers::save_files_handler::SaveFilesHandler;
 use super::state_machine_handlers::save_settings_handler::SaveSettingsHandler;
@@ -60,6 +61,7 @@ enum CreateAppStates {
     SaveSettings,
     SaveFiles,
     CreateLoadBalancerConfig,
+    EnsureAppNetwork,
     RunDockerComposeBuildAndRun,
     RunPostActions,
     UpdateAppData,
@@ -100,9 +102,16 @@ async fn create_app_prepare(
     sm.add_handler(
         CreateAppStates::CreateLoadBalancerConfig,
         Arc::new(CreateLoadBalancerConfig::<CreateAppStates> {
-            next_state: CreateAppStates::RunDockerComposeBuildAndRun,
+            next_state: CreateAppStates::EnsureAppNetwork,
             load_balancer_type: app_state.settings.load_balancer_type.clone(),
             settings: settings.clone(),
+        }),
+    );
+
+    sm.add_handler(
+        CreateAppStates::EnsureAppNetwork,
+        Arc::new(EnsureAppNetworkHandler::<CreateAppStates> {
+            next_state: CreateAppStates::RunDockerComposeBuildAndRun,
         }),
     );
 

--- a/scotty/src/docker/create_app.rs
+++ b/scotty/src/docker/create_app.rs
@@ -21,7 +21,6 @@ use super::rebuild_app::rebuild_app_prepare;
 use super::state_machine_handlers::context::Context;
 use super::state_machine_handlers::create_directory_handler::CreateDirectoryHandler;
 use super::state_machine_handlers::create_load_balancer_config::CreateLoadBalancerConfig;
-use super::state_machine_handlers::network_handler::EnsureAppNetworkHandler;
 use super::state_machine_handlers::run_post_actions_handler::RunPostActionsHandler;
 use super::state_machine_handlers::save_files_handler::SaveFilesHandler;
 use super::state_machine_handlers::save_settings_handler::SaveSettingsHandler;
@@ -61,7 +60,6 @@ enum CreateAppStates {
     SaveSettings,
     SaveFiles,
     CreateLoadBalancerConfig,
-    EnsureAppNetwork,
     RunDockerComposeBuildAndRun,
     RunPostActions,
     UpdateAppData,
@@ -102,19 +100,16 @@ async fn create_app_prepare(
     sm.add_handler(
         CreateAppStates::CreateLoadBalancerConfig,
         Arc::new(CreateLoadBalancerConfig::<CreateAppStates> {
-            next_state: CreateAppStates::EnsureAppNetwork,
+            next_state: CreateAppStates::RunDockerComposeBuildAndRun,
             load_balancer_type: app_state.settings.load_balancer_type.clone(),
             settings: settings.clone(),
         }),
     );
 
-    sm.add_handler(
-        CreateAppStates::EnsureAppNetwork,
-        Arc::new(EnsureAppNetworkHandler::<CreateAppStates> {
-            next_state: CreateAppStates::RunDockerComposeBuildAndRun,
-        }),
-    );
-
+    // Note: the per-app network is ensured by the nested rebuild state machine
+    // (RunDockerComposeBuildHandler delegates to rebuild_app_prepare, which runs
+    // EnsureAppNetworkHandler before any compose command), so create_app does
+    // not ensure it separately.
     sm.add_handler(
         CreateAppStates::RunDockerComposeBuildAndRun,
         Arc::new(RunDockerComposeBuildHandler::<CreateAppStates> {

--- a/scotty/src/docker/destroy_app.rs
+++ b/scotty/src/docker/destroy_app.rs
@@ -33,6 +33,10 @@ impl StateHandler<DestroyAppStates, Context> for RunDockerComposeDownHandler<Des
         _from: &DestroyAppStates,
         context: Arc<RwLock<Context>>,
     ) -> anyhow::Result<DestroyAppStates> {
+        // Delegates compose-down to purge_app_prepare(Down), which also runs
+        // TeardownAppNetworkHandler. That is why destroy has no explicit network
+        // teardown state of its own: the per-app proxy network is removed here,
+        // via the nested purge state machine.
         let sm = purge_app_prepare(&self.app, PurgeAppMethod::Down).await?;
         let handle = sm.spawn(context.clone());
 

--- a/scotty/src/docker/loadbalancer/mod.rs
+++ b/scotty/src/docker/loadbalancer/mod.rs
@@ -13,6 +13,11 @@ pub mod types;
 /// Must stay in sync between the compose-override generation
 /// (`traefik.rs`) and the network lifecycle handlers, which both build the
 /// name from the same inputs.
+///
+/// `app_name` is expected to be a slug (Scotty slugifies app names on
+/// create/adopt), which keeps the result within Docker's allowed network-name
+/// character set. The name is a 1:1 function of `app_name`, so two distinct
+/// apps only collide here if they already collide on app name.
 pub fn app_proxy_network_name(base_network: &str, app_name: &str) -> String {
     format!("{base_network}--{app_name}")
 }

--- a/scotty/src/docker/loadbalancer/mod.rs
+++ b/scotty/src/docker/loadbalancer/mod.rs
@@ -16,8 +16,10 @@ pub mod types;
 ///
 /// `app_name` is expected to be a slug (Scotty slugifies app names on
 /// create/adopt), which keeps the result within Docker's allowed network-name
-/// character set. The name is a 1:1 function of `app_name`, so two distinct
-/// apps only collide here if they already collide on app name.
+/// character set. The join is not injective if `base_network` itself contains
+/// `--` (e.g. base `proxy--region` + app `foo` yields the same name as base
+/// `proxy` + app `region--foo`); the default base `proxy` has no dashes, so in
+/// practice the network name is determined by the app name.
 pub fn app_proxy_network_name(base_network: &str, app_name: &str) -> String {
     format!("{base_network}--{app_name}")
 }

--- a/scotty/src/docker/loadbalancer/mod.rs
+++ b/scotty/src/docker/loadbalancer/mod.rs
@@ -2,3 +2,17 @@ pub mod factory;
 pub mod haproxy;
 pub mod traefik;
 pub mod types;
+
+/// Computes the name of the per-app Traefik proxy network.
+///
+/// Each app gets its own dedicated external network (derived from the
+/// configured base network name plus the app name) instead of all apps
+/// sharing one global network. This keeps each app's Docker DNS namespace
+/// isolated so service names (e.g. `nginx`) can never collide across apps.
+///
+/// Must stay in sync between the compose-override generation
+/// (`traefik.rs`) and the network lifecycle handlers, which both build the
+/// name from the same inputs.
+pub fn app_proxy_network_name(base_network: &str, app_name: &str) -> String {
+    format!("{base_network}--{app_name}")
+}

--- a/scotty/src/docker/loadbalancer/traefik.rs
+++ b/scotty/src/docker/loadbalancer/traefik.rs
@@ -6,9 +6,10 @@ use regex::Regex;
 use crate::settings::config::Settings;
 use scotty_core::apps::app_data::AppSettings;
 
+use super::app_proxy_network_name;
 use super::types::{
     DockerComposeConfig, DockerComposeNetworkConfig, DockerComposeServiceConfig, LoadBalancerImpl,
-    LoadBalancerInfo,
+    LoadBalancerInfo, ServiceNetworkAttachment,
 };
 
 pub struct TraefikLoadBalancer;
@@ -58,11 +59,18 @@ impl LoadBalancerImpl for TraefikLoadBalancer {
             networks: Some(HashMap::new()),
         };
 
-        // Setup external network with traefik
+        // Each app gets its own dedicated external proxy network instead of a
+        // single shared one, so Docker DNS names never collide across apps.
+        // Scotty creates this network and connects Traefik to it via the
+        // network lifecycle handlers; here we only reference it as external.
+        let app_network = app_proxy_network_name(&global_settings.traefik.network, app_name);
         let networks = config.networks.as_mut().unwrap();
         networks.insert(
-            global_settings.traefik.network.clone(),
-            DockerComposeNetworkConfig { external: true },
+            app_network.clone(),
+            DockerComposeNetworkConfig {
+                external: true,
+                name: Some(app_network.clone()),
+            },
         );
 
         // First, apply environment variables to all services
@@ -101,17 +109,33 @@ impl LoadBalancerImpl for TraefikLoadBalancer {
             if service_config.environment.is_none() {
                 service_config.environment = Some(HashMap::new());
             }
-            // Initialize or update networks
-            service_config.networks = Some(vec![
-                "default".into(),
-                global_settings.traefik.network.clone(),
-            ]);
+            let service_name = format!("{}--{}", &service.service, &app_name);
+
+            // Attach the public service to its project `default` network and to
+            // the per-app proxy network. On the proxy network we set an explicit
+            // app-scoped alias so the service is reachable under a unique name
+            // (Compose still adds the bare service name as an alias, but the
+            // network itself is no longer shared, so that no longer collides).
+            let mut service_networks = std::collections::HashMap::new();
+            service_networks.insert("default".to_string(), ServiceNetworkAttachment::default());
+            service_networks.insert(
+                app_network.clone(),
+                ServiceNetworkAttachment {
+                    aliases: Some(vec![service_name.clone()]),
+                },
+            );
+            service_config.networks = Some(service_networks);
 
             let labels = service_config.labels.as_mut().unwrap();
-            let service_name = format!("{}--{}", &service.service, &app_name);
 
             // Add Traefik labels
             labels.insert("traefik.enable".to_string(), "true".to_string());
+
+            // Tell Traefik which network to use to reach this container. The
+            // container is on multiple networks and Traefik only resolves the
+            // backend IP once at discovery time, so this label is required for
+            // correct routing.
+            labels.insert("traefik.docker.network".to_string(), app_network.clone());
 
             let domains = service.get_domains(&settings.domain);
             for (idx, domain) in domains.iter().enumerate() {
@@ -262,13 +286,34 @@ mod tests {
         let labels = service_config.labels.as_ref().unwrap();
         let environment = service_config.environment.as_ref().unwrap();
 
-        // check networks.
+        // check networks: the service joins its `default` network and the
+        // per-app proxy network (base "proxy" + app "myapp"), with an
+        // app-scoped alias on the proxy network.
         let networks = service_config.networks.as_ref().unwrap();
-        assert!(networks.contains(&"default".to_string()));
-        assert!(networks.contains(&"proxy".to_string()));
+        assert!(networks.contains_key("default"));
+        assert!(networks.contains_key("proxy--myapp"));
+        assert_eq!(
+            networks
+                .get("proxy--myapp")
+                .unwrap()
+                .aliases
+                .as_ref()
+                .unwrap(),
+            &vec!["web--myapp".to_string()]
+        );
+
+        // The top-level network definition is the per-app external network.
+        let defined_networks = result.networks.as_ref().unwrap();
+        let net = defined_networks.get("proxy--myapp").unwrap();
+        assert!(net.external);
+        assert_eq!(net.name.as_deref(), Some("proxy--myapp"));
 
         // Check labels.
         assert_eq!(labels.get("traefik.enable").unwrap(), "true");
+        assert_eq!(
+            labels.get("traefik.docker.network").unwrap(),
+            "proxy--myapp"
+        );
         assert_eq!(
             labels
                 .get("traefik.http.routers.web--myapp-0.rule")
@@ -308,6 +353,50 @@ mod tests {
         // check environment.
         assert_eq!(environment.get("FOO").unwrap(), "BAR");
         assert_eq!(environment.get("API_KEY").unwrap(), "1234");
+    }
+
+    #[test]
+    fn test_traefik_override_serializes_to_valid_compose() {
+        let global_settings = Settings {
+            traefik: TraefikSettings::new(false, "proxy".into(), None, vec![]),
+            ..Default::default()
+        };
+        let app_settings = AppSettings {
+            domain: "example.com".to_string(),
+            public_services: vec![ServicePortMapping {
+                service: "nginx".to_string(),
+                port: 80,
+                domains: vec![],
+            }],
+            ..Default::default()
+        };
+
+        let result = TraefikLoadBalancer
+            .get_docker_compose_override(
+                &global_settings,
+                "stiftung",
+                &app_settings,
+                &app_settings.environment.expose_all(),
+                &["nginx".to_string()],
+            )
+            .unwrap();
+
+        let yaml = serde_norway::to_string(&result).unwrap();
+
+        // The serialized override must round-trip as valid YAML and carry the
+        // per-app network with an app-scoped alias (not the bare service name).
+        let parsed: serde_norway::Value = serde_norway::from_str(&yaml).unwrap();
+        let net = &parsed["services"]["nginx"]["networks"];
+        assert!(
+            net.get("default").is_some(),
+            "missing default network in:\n{yaml}"
+        );
+        let aliases = &parsed["services"]["nginx"]["networks"]["proxy--stiftung"]["aliases"];
+        assert_eq!(aliases[0].as_str(), Some("nginx--stiftung"));
+        assert_eq!(
+            parsed["networks"]["proxy--stiftung"]["external"].as_bool(),
+            Some(true)
+        );
     }
 
     #[test]

--- a/scotty/src/docker/loadbalancer/traefik.rs
+++ b/scotty/src/docker/loadbalancer/traefik.rs
@@ -397,6 +397,12 @@ mod tests {
             net.get("default").is_some(),
             "missing default network in:\n{yaml}"
         );
+        // Pin the empty-attachment shape: `default: {}` (a mapping), not `null`.
+        assert!(
+            net["default"].is_mapping(),
+            "expected `default` to serialize as a mapping, got: {:?}\n{yaml}",
+            net.get("default")
+        );
         let aliases = &parsed["services"]["nginx"]["networks"]["proxy--stiftung"]["aliases"];
         assert_eq!(aliases[0].as_str(), Some("nginx--stiftung"));
         assert_eq!(

--- a/scotty/src/docker/loadbalancer/traefik.rs
+++ b/scotty/src/docker/loadbalancer/traefik.rs
@@ -245,7 +245,13 @@ mod tests {
     #[test]
     fn test_traefik_get_docker_compose_override() {
         let global_settings = Settings {
-            traefik: TraefikSettings::new(true, "proxy".into(), Some("myresolver".into()), vec![], "traefik".into()),
+            traefik: TraefikSettings::new(
+                true,
+                "proxy".into(),
+                Some("myresolver".into()),
+                vec![],
+                "traefik".into(),
+            ),
             ..Default::default()
         };
 
@@ -402,7 +408,13 @@ mod tests {
     #[test]
     fn test_traefik_env_vars_applied_to_all_containers() {
         let global_settings = Settings {
-            traefik: TraefikSettings::new(true, "proxy".into(), Some("myresolver".into()), vec![], "traefik".into()),
+            traefik: TraefikSettings::new(
+                true,
+                "proxy".into(),
+                Some("myresolver".into()),
+                vec![],
+                "traefik".into(),
+            ),
             ..Default::default()
         };
 

--- a/scotty/src/docker/loadbalancer/traefik.rs
+++ b/scotty/src/docker/loadbalancer/traefik.rs
@@ -245,7 +245,7 @@ mod tests {
     #[test]
     fn test_traefik_get_docker_compose_override() {
         let global_settings = Settings {
-            traefik: TraefikSettings::new(true, "proxy".into(), Some("myresolver".into()), vec![]),
+            traefik: TraefikSettings::new(true, "proxy".into(), Some("myresolver".into()), vec![], "traefik".into()),
             ..Default::default()
         };
 
@@ -358,7 +358,7 @@ mod tests {
     #[test]
     fn test_traefik_override_serializes_to_valid_compose() {
         let global_settings = Settings {
-            traefik: TraefikSettings::new(false, "proxy".into(), None, vec![]),
+            traefik: TraefikSettings::new(false, "proxy".into(), None, vec![], "traefik".into()),
             ..Default::default()
         };
         let app_settings = AppSettings {
@@ -402,7 +402,7 @@ mod tests {
     #[test]
     fn test_traefik_env_vars_applied_to_all_containers() {
         let global_settings = Settings {
-            traefik: TraefikSettings::new(true, "proxy".into(), Some("myresolver".into()), vec![]),
+            traefik: TraefikSettings::new(true, "proxy".into(), Some("myresolver".into()), vec![], "traefik".into()),
             ..Default::default()
         };
 

--- a/scotty/src/docker/loadbalancer/types.rs
+++ b/scotty/src/docker/loadbalancer/types.rs
@@ -26,19 +26,37 @@ impl Default for LoadBalancerInfo {
     }
 }
 
+/// Per-service attachment to a single network in the Compose long syntax.
+///
+/// Compose always registers the service name as a network alias on every
+/// network the service joins, which collides across projects on a shared
+/// network. Setting an explicit, app-scoped alias here keeps the service
+/// reachable under a unique name on the per-app proxy network.
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+pub struct ServiceNetworkAttachment {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub aliases: Option<Vec<String>>,
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct DockerComposeServiceConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub labels: Option<HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub environment: Option<HashMap<String, String>>,
+    // Compose long syntax: map of network name -> attachment config. An empty
+    // attachment (`{}`) simply joins the network; aliases scope the DNS name.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub networks: Option<Vec<String>>,
+    pub networks: Option<HashMap<String, ServiceNetworkAttachment>>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct DockerComposeNetworkConfig {
     pub external: bool,
+    /// Explicit external network name. Set so Compose references the network
+    /// Scotty created verbatim instead of prefixing it with the project name.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]

--- a/scotty/src/docker/purge_app.rs
+++ b/scotty/src/docker/purge_app.rs
@@ -6,7 +6,8 @@ use crate::{
     api::error::AppError,
     app_state::SharedAppState,
     docker::state_machine_handlers::{
-        context::Context, run_docker_compose_handler::RunDockerComposeHandler,
+        context::Context, network_handler::TeardownAppNetworkHandler,
+        run_docker_compose_handler::RunDockerComposeHandler,
         task_completion_handler::TaskCompletionHandler,
         update_app_data_handler::UpdateAppDataHandler,
     },
@@ -21,6 +22,7 @@ use super::helper::run_sm;
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 pub enum PurgeAppStates {
     RunDockerCompose,
+    TeardownAppNetwork,
     UpdateAppData,
     SetFinished,
     SetFailed,
@@ -50,9 +52,15 @@ pub async fn purge_app_prepare(
     sm.add_handler(
         PurgeAppStates::RunDockerCompose,
         Arc::new(RunDockerComposeHandler::<PurgeAppStates> {
-            next_state: PurgeAppStates::UpdateAppData,
+            next_state: PurgeAppStates::TeardownAppNetwork,
             command: command.iter().map(|s| s.to_string()).collect(),
             env: app.get_environment(),
+        }),
+    );
+    sm.add_handler(
+        PurgeAppStates::TeardownAppNetwork,
+        Arc::new(TeardownAppNetworkHandler::<PurgeAppStates> {
+            next_state: PurgeAppStates::UpdateAppData,
         }),
     );
     sm.add_handler(

--- a/scotty/src/docker/rebuild_app.rs
+++ b/scotty/src/docker/rebuild_app.rs
@@ -27,10 +27,10 @@ use scotty_core::tasks::running_app_context::RunningAppContext;
 pub enum RebuildAppStates {
     RecreateLoadBalancerConfig,
     RunDockerLogin,
+    EnsureAppNetwork,
     RunDockerComposePull,
     RunDockerComposeBuild,
     RunDockerComposeStop,
-    EnsureAppNetwork,
     RunDockerComposeRun,
     WaitForAllContainers,
     RunPostActions,

--- a/scotty/src/docker/rebuild_app.rs
+++ b/scotty/src/docker/rebuild_app.rs
@@ -75,8 +75,18 @@ pub async fn rebuild_app_prepare(
     sm.add_handler(
         RebuildAppStates::RunDockerLogin,
         Arc::new(RunDockerLoginHandler::<RebuildAppStates> {
-            next_state: RebuildAppStates::RunDockerComposePull,
+            next_state: RebuildAppStates::EnsureAppNetwork,
             registry: app.get_registry(),
+        }),
+    );
+    // Ensure the per-app network exists before ANY compose subcommand runs:
+    // the override declares it as external, and compose can reject commands
+    // (e.g. on a freshly adopted app, or after the network was removed) when a
+    // declared external network is missing.
+    sm.add_handler(
+        RebuildAppStates::EnsureAppNetwork,
+        Arc::new(EnsureAppNetworkHandler::<RebuildAppStates> {
+            next_state: RebuildAppStates::RunDockerComposePull,
         }),
     );
     sm.add_handler(
@@ -98,15 +108,9 @@ pub async fn rebuild_app_prepare(
     sm.add_handler(
         RebuildAppStates::RunDockerComposeStop,
         Arc::new(RunDockerComposeHandler::<RebuildAppStates> {
-            next_state: RebuildAppStates::EnsureAppNetwork,
+            next_state: RebuildAppStates::RunDockerComposeRun,
             command: ["stop"].iter().map(|s| s.to_string()).collect(),
             env: app.get_environment(),
-        }),
-    );
-    sm.add_handler(
-        RebuildAppStates::EnsureAppNetwork,
-        Arc::new(EnsureAppNetworkHandler::<RebuildAppStates> {
-            next_state: RebuildAppStates::RunDockerComposeRun,
         }),
     );
     sm.add_handler(

--- a/scotty/src/docker/rebuild_app.rs
+++ b/scotty/src/docker/rebuild_app.rs
@@ -9,6 +9,7 @@ use crate::{
     app_state::SharedAppState,
     docker::state_machine_handlers::{
         context::Context, create_load_balancer_config::CreateLoadBalancerConfig,
+        network_handler::EnsureAppNetworkHandler,
         run_docker_compose_handler::RunDockerComposeHandler,
         run_docker_login_handler::RunDockerLoginHandler,
         run_post_actions_handler::RunPostActionsHandler,
@@ -29,6 +30,7 @@ pub enum RebuildAppStates {
     RunDockerComposePull,
     RunDockerComposeBuild,
     RunDockerComposeStop,
+    EnsureAppNetwork,
     RunDockerComposeRun,
     WaitForAllContainers,
     RunPostActions,
@@ -96,9 +98,15 @@ pub async fn rebuild_app_prepare(
     sm.add_handler(
         RebuildAppStates::RunDockerComposeStop,
         Arc::new(RunDockerComposeHandler::<RebuildAppStates> {
-            next_state: RebuildAppStates::RunDockerComposeRun,
+            next_state: RebuildAppStates::EnsureAppNetwork,
             command: ["stop"].iter().map(|s| s.to_string()).collect(),
             env: app.get_environment(),
+        }),
+    );
+    sm.add_handler(
+        RebuildAppStates::EnsureAppNetwork,
+        Arc::new(EnsureAppNetworkHandler::<RebuildAppStates> {
+            next_state: RebuildAppStates::RunDockerComposeRun,
         }),
     );
     sm.add_handler(

--- a/scotty/src/docker/run_app.rs
+++ b/scotty/src/docker/run_app.rs
@@ -6,7 +6,8 @@ use crate::{
     api::error::AppError,
     app_state::SharedAppState,
     docker::state_machine_handlers::{
-        context::Context, run_docker_compose_handler::RunDockerComposeHandler,
+        context::Context, network_handler::EnsureAppNetworkHandler,
+        run_docker_compose_handler::RunDockerComposeHandler,
         run_docker_login_handler::RunDockerLoginHandler,
         run_post_actions_handler::RunPostActionsHandler,
         task_completion_handler::TaskCompletionHandler,
@@ -25,6 +26,7 @@ use super::helper::run_sm;
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 enum RunAppStates {
     RunDockerLogin,
+    EnsureAppNetwork,
     RunDockerCompose,
     WaitForAllContainers,
     RunPostActions,
@@ -43,8 +45,15 @@ async fn run_app_prepare(app: &AppData) -> anyhow::Result<StateMachine<RunAppSta
     sm.add_handler(
         RunAppStates::RunDockerLogin,
         Arc::new(RunDockerLoginHandler::<RunAppStates> {
-            next_state: RunAppStates::RunDockerCompose,
+            next_state: RunAppStates::EnsureAppNetwork,
             registry: app.get_registry(),
+        }),
+    );
+
+    sm.add_handler(
+        RunAppStates::EnsureAppNetwork,
+        Arc::new(EnsureAppNetworkHandler::<RunAppStates> {
+            next_state: RunAppStates::RunDockerCompose,
         }),
     );
 

--- a/scotty/src/docker/state_machine_handlers/create_load_balancer_config.rs
+++ b/scotty/src/docker/state_machine_handlers/create_load_balancer_config.rs
@@ -149,7 +149,7 @@ mod tests {
         };
 
         let global_settings = Settings {
-            traefik: TraefikSettings::new(false, "proxy".into(), None, vec![]),
+            traefik: TraefikSettings::new(false, "proxy".into(), None, vec![], "traefik".into()),
             ..Default::default()
         };
 

--- a/scotty/src/docker/state_machine_handlers/mod.rs
+++ b/scotty/src/docker/state_machine_handlers/mod.rs
@@ -1,6 +1,7 @@
 pub mod context;
 pub mod create_directory_handler;
 pub mod create_load_balancer_config;
+pub mod network_handler;
 pub mod remove_directory_handler;
 pub mod run_docker_compose_handler;
 pub mod run_docker_login_handler;

--- a/scotty/src/docker/state_machine_handlers/network_handler.rs
+++ b/scotty/src/docker/state_machine_handlers/network_handler.rs
@@ -1,0 +1,165 @@
+use std::sync::Arc;
+
+use bollard::errors::Error as BollardError;
+use bollard_stubs::models::{
+    NetworkConnectRequest, NetworkCreateRequest, NetworkDisconnectRequest,
+};
+use scotty_core::settings::loadbalancer::LoadBalancerType;
+use tokio::sync::RwLock;
+use tracing::{info, instrument, warn};
+
+use crate::docker::loadbalancer::app_proxy_network_name;
+use crate::state_machine::StateHandler;
+
+use super::context::Context;
+
+/// Returns the HTTP status code for a Docker daemon error, if any.
+fn server_status(err: &BollardError) -> Option<u16> {
+    match err {
+        BollardError::DockerResponseServerError { status_code, .. } => Some(*status_code),
+        _ => None,
+    }
+}
+
+/// Resolves the per-app proxy network name and the Traefik container to
+/// connect to, or `None` when load balancing is not Traefik (e.g. HAProxy),
+/// in which case the network handlers are a no-op.
+fn proxy_network_target(context: &Context) -> Option<(String, String)> {
+    let settings = &context.app_state.settings;
+    if settings.load_balancer_type != LoadBalancerType::Traefik {
+        return None;
+    }
+    let network = app_proxy_network_name(&settings.traefik.network, &context.app_data.name);
+    let container = settings.traefik.container_name.clone();
+    Some((network, container))
+}
+
+/// Creates the app's dedicated proxy network (if missing) and connects the
+/// Traefik container to it. Runs before `docker compose up`, because the
+/// override declares the network as external and Compose fails if it does not
+/// already exist. All operations are idempotent so retries are safe.
+#[derive(Debug)]
+pub struct EnsureAppNetworkHandler<S>
+where
+    S: Send + Sync + Clone + std::fmt::Debug,
+{
+    pub next_state: S,
+}
+
+#[async_trait::async_trait]
+impl<S> StateHandler<S, Context> for EnsureAppNetworkHandler<S>
+where
+    S: Send + Sync + Clone + std::fmt::Debug,
+{
+    #[instrument(skip(context))]
+    async fn transition(&self, _from: &S, context: Arc<RwLock<Context>>) -> anyhow::Result<S> {
+        let context = context.read().await;
+        let Some((network, container)) = proxy_network_target(&context) else {
+            return Ok(self.next_state.clone());
+        };
+        let docker = &context.app_state.docker;
+
+        // Create the network. Ignore 409 (already exists) for idempotency.
+        let mut labels = std::collections::HashMap::new();
+        labels.insert("scotty.managed".to_string(), "true".to_string());
+        labels.insert("scotty.app".to_string(), context.app_data.name.clone());
+        match docker
+            .create_network(NetworkCreateRequest {
+                name: network.clone(),
+                labels: Some(labels),
+                ..Default::default()
+            })
+            .await
+        {
+            Ok(_) => info!("Created proxy network {}", network),
+            Err(e) if server_status(&e) == Some(409) => {
+                info!("Proxy network {} already exists", network);
+            }
+            Err(e) => return Err(anyhow::Error::from(e)),
+        }
+
+        // Connect Traefik to the network. Ignore 403 (already connected). A
+        // missing Traefik container (404) is logged but not fatal: the app
+        // still runs, it just is not routable until Traefik is available.
+        match docker
+            .connect_network(
+                &network,
+                NetworkConnectRequest {
+                    container: container.clone(),
+                    endpoint_config: None,
+                },
+            )
+            .await
+        {
+            Ok(_) => info!("Connected Traefik ({}) to network {}", container, network),
+            Err(e) if server_status(&e) == Some(403) => {
+                info!("Traefik ({}) already connected to {}", container, network);
+            }
+            Err(e) if server_status(&e) == Some(404) => {
+                warn!(
+                    "Traefik container '{}' not found; app on network {} will not be routable until it is connected",
+                    container, network
+                );
+            }
+            Err(e) => return Err(anyhow::Error::from(e)),
+        }
+
+        Ok(self.next_state.clone())
+    }
+}
+
+/// Disconnects Traefik from the app's proxy network and removes the network.
+/// Runs after `docker compose down`/`rm`, because Docker refuses to remove a
+/// network while an endpoint (Traefik) is still attached. All operations are
+/// idempotent and best-effort: teardown never fails the surrounding task.
+#[derive(Debug)]
+pub struct TeardownAppNetworkHandler<S>
+where
+    S: Send + Sync + Clone + std::fmt::Debug,
+{
+    pub next_state: S,
+}
+
+#[async_trait::async_trait]
+impl<S> StateHandler<S, Context> for TeardownAppNetworkHandler<S>
+where
+    S: Send + Sync + Clone + std::fmt::Debug,
+{
+    #[instrument(skip(context))]
+    async fn transition(&self, _from: &S, context: Arc<RwLock<Context>>) -> anyhow::Result<S> {
+        let context = context.read().await;
+        let Some((network, container)) = proxy_network_target(&context) else {
+            return Ok(self.next_state.clone());
+        };
+        let docker = &context.app_state.docker;
+
+        // Disconnect Traefik. Ignore "not found / not connected" (404).
+        match docker
+            .disconnect_network(
+                &network,
+                NetworkDisconnectRequest {
+                    container: container.clone(),
+                    force: Some(true),
+                },
+            )
+            .await
+        {
+            Ok(_) => info!(
+                "Disconnected Traefik ({}) from network {}",
+                container, network
+            ),
+            Err(e) if server_status(&e) == Some(404) => {}
+            Err(e) => warn!("Failed to disconnect Traefik from {}: {}", network, e),
+        }
+
+        // Remove the network. Ignore 404 (already gone); a 403 means other
+        // endpoints are still attached, in which case we leave it in place.
+        match docker.remove_network(&network).await {
+            Ok(_) => info!("Removed proxy network {}", network),
+            Err(e) if server_status(&e) == Some(404) => {}
+            Err(e) => warn!("Could not remove proxy network {}: {}", network, e),
+        }
+
+        Ok(self.next_state.clone())
+    }
+}

--- a/scotty/src/docker/state_machine_handlers/network_handler.rs
+++ b/scotty/src/docker/state_machine_handlers/network_handler.rs
@@ -92,7 +92,11 @@ where
             .await
         {
             Ok(_) => info!("Connected Traefik ({}) to network {}", container, network),
-            Err(e) if server_status(&e) == Some(403) => {
+            // Already connected. The exact status is version-dependent: older
+            // daemons raise a libnetwork "endpoint already exists" ForbiddenError
+            // (403), newer ones a Conflict (409). Treat both as benign so the
+            // handler is idempotent across Docker versions.
+            Err(e) if matches!(server_status(&e), Some(403 | 409)) => {
                 info!("Traefik ({}) already connected to {}", container, network);
             }
             Err(e) if server_status(&e) == Some(404) => {
@@ -152,7 +156,7 @@ where
             Err(e) => warn!("Failed to disconnect Traefik from {}: {}", network, e),
         }
 
-        // Remove the network. Ignore 404 (already gone); a 403 means other
+        // Remove the network. Ignore 404 (already gone); a 409 means other
         // endpoints are still attached, in which case we leave it in place.
         match docker.remove_network(&network).await {
             Ok(_) => info!("Removed proxy network {}", network),

--- a/scotty/src/docker/state_machine_handlers/network_handler.rs
+++ b/scotty/src/docker/state_machine_handlers/network_handler.rs
@@ -6,7 +6,7 @@ use bollard_stubs::models::{
 };
 use scotty_core::settings::loadbalancer::LoadBalancerType;
 use tokio::sync::RwLock;
-use tracing::{info, instrument, warn};
+use tracing::{error, info, instrument, warn};
 
 use crate::docker::loadbalancer::app_proxy_network_name;
 use crate::state_machine::StateHandler;
@@ -100,8 +100,13 @@ where
                 info!("Traefik ({}) already connected to {}", container, network);
             }
             Err(e) if server_status(&e) == Some(404) => {
+                // 404 covers both "Traefik container missing" and "network
+                // missing" (e.g. a concurrent destroy removed the network we
+                // just created). We proceed best-effort; if it is the network
+                // that is gone, the subsequent `compose up` surfaces it as a
+                // hard failure.
                 warn!(
-                    "Traefik container '{}' not found; app on network {} will not be routable until it is connected",
+                    "connect_network returned 404 for Traefik '{}' on network {} (container or network missing); app may not be routable",
                     container, network
                 );
             }
@@ -175,7 +180,10 @@ where
         match docker.remove_network(&network).await {
             Ok(_) => info!("Removed proxy network {}", network),
             Err(e) if server_status(&e) == Some(404) => {}
-            Err(e) => warn!("Could not remove proxy network {}: {}", network, e),
+            // The network could not be removed and is now leaked (e.g. Traefik
+            // is still attached). Surface at error! with the name so an operator
+            // can clean it up; it is also reclaimable on the next purge.
+            Err(e) => error!("Leaked proxy network {} (removal failed): {}", network, e),
         }
 
         Ok(self.next_state.clone())

--- a/scotty/src/docker/state_machine_handlers/network_handler.rs
+++ b/scotty/src/docker/state_machine_handlers/network_handler.rs
@@ -156,7 +156,17 @@ where
                 "Disconnected Traefik ({}) from network {}",
                 container, network
             ),
-            Err(e) if matches!(server_status(&e), Some(403 | 404 | 409)) => {}
+            Err(e) if matches!(server_status(&e), Some(403 | 404 | 409)) => {
+                // Benign "already disconnected / not connected" case. Log it so
+                // that, if remove_network then reports a lingering endpoint, the
+                // teardown trace is complete rather than a lone unexplained warning.
+                info!(
+                    "Traefik ({}) already disconnected from {} (status {:?})",
+                    container,
+                    network,
+                    server_status(&e)
+                );
+            }
             Err(e) => warn!("Failed to disconnect Traefik from {}: {}", network, e),
         }
 

--- a/scotty/src/docker/state_machine_handlers/network_handler.rs
+++ b/scotty/src/docker/state_machine_handlers/network_handler.rs
@@ -137,7 +137,11 @@ where
         };
         let docker = &context.app_state.docker;
 
-        // Disconnect Traefik. Ignore "not found / not connected" (404).
+        // Disconnect Traefik. `force` is intentional: the app's containers are
+        // already down at teardown time, so there is no in-flight request to
+        // disrupt, and force lets the disconnect succeed regardless of endpoint
+        // state. Tolerate "not found / not connected", whose status is
+        // version-dependent (403/404/409), so teardown stays idempotent.
         match docker
             .disconnect_network(
                 &network,
@@ -152,7 +156,7 @@ where
                 "Disconnected Traefik ({}) from network {}",
                 container, network
             ),
-            Err(e) if server_status(&e) == Some(404) => {}
+            Err(e) if matches!(server_status(&e), Some(403 | 404 | 409)) => {}
             Err(e) => warn!("Failed to disconnect Traefik from {}: {}", network, e),
         }
 

--- a/scotty/src/docker/state_machine_handlers/network_handler.rs
+++ b/scotty/src/docker/state_machine_handlers/network_handler.rs
@@ -63,6 +63,8 @@ where
         let mut labels = std::collections::HashMap::new();
         labels.insert("scotty.managed".to_string(), "true".to_string());
         labels.insert("scotty.app".to_string(), context.app_data.name.clone());
+        // Defaults give a local bridge network with Docker-assigned IPAM, which
+        // is what Traefik's container-to-container routing expects here.
         match docker
             .create_network(NetworkCreateRequest {
                 name: network.clone(),
@@ -181,9 +183,13 @@ where
             Ok(_) => info!("Removed proxy network {}", network),
             Err(e) if server_status(&e) == Some(404) => {}
             // The network could not be removed and is now leaked (e.g. Traefik
-            // is still attached). Surface at error! with the name so an operator
-            // can clean it up; it is also reclaimable on the next purge.
-            Err(e) => error!("Leaked proxy network {} (removal failed): {}", network, e),
+            // is still attached, which usually traces back to the disconnect
+            // warning logged just above). Surface at error! with the name so an
+            // operator can clean it up; it is also reclaimable on the next purge.
+            Err(e) => error!(
+                "Leaked proxy network {} (removal failed; Traefik may still be attached, see preceding disconnect log): {}",
+                network, e
+            ),
         }
 
         Ok(self.next_state.clone())

--- a/scotty/src/docker/stop_app.rs
+++ b/scotty/src/docker/stop_app.rs
@@ -36,6 +36,11 @@ pub async fn stop_app_prepare(
     let mut sm = StateMachine::new(StopAppStates::RunDockerCompose, StopAppStates::Done);
     sm.set_error_state(StopAppStates::SetFailed);
 
+    // Intentionally no EnsureAppNetwork/TeardownAppNetwork here: `compose stop`
+    // neither attaches nor validates networks, and the app's containers stay in
+    // place (and on the per-app network), so the network must NOT be removed. Do
+    // not add network teardown to stop — it would orphan running containers from
+    // their network and break the next `app:run`.
     sm.add_handler(
         StopAppStates::RunDockerCompose,
         Arc::new(RunDockerComposeHandler::<StopAppStates> {

--- a/scotty/src/settings/config.rs
+++ b/scotty/src/settings/config.rs
@@ -150,6 +150,18 @@ impl Settings {
             .validate()
             .map_err(|e| ConfigError::Message(e.to_string()))?;
 
+        // The per-app proxy network is named `<traefik.network>--<app>`, so a
+        // base network containing `--` makes the derived name non-unique across
+        // apps (base `a--b` + app `c` collides with base `a` + app `b--c`).
+        if settings.load_balancer_type == LoadBalancerType::Traefik
+            && settings.traefik.network.contains("--")
+        {
+            return Err(ConfigError::Message(format!(
+                "traefik.network must not contain '--' (got {:?}); it is the base for per-app network names",
+                settings.traefik.network
+            )));
+        }
+
         Ok(settings)
     }
 


### PR DESCRIPTION
## Problem

Scotty attached every public service to a single, global, external Traefik network (default `proxy`). Docker Compose registers each service's **name** as a network alias on every network it joins, so every app with an `nginx` public service published the same `nginx` alias onto that one shared network. Docker's embedded DNS then resolved `nginx` (and any other colliding service name) ambiguously across apps. Because a public container's resolution scope is the union of all its networks, an in-app proxy (e.g. forwarding `/api` to a Drupal nginx) could resolve to a **foreign** container in another app.

This broke in-app routing for the `stiftung` and `tel` apps. See #848 for the full analysis.

Note: Compose's auto-added service-name alias cannot be suppressed via `aliases:` (they are additive), so the names have to live in **separate** network namespaces — which is the documented Traefik fix (per-app networks + `traefik.docker.network`).

## Solution

Give each app its own Scotty-owned external proxy network and manage Traefik's membership of it from the app lifecycle state machine.

**Compose override (`loadbalancer/`)**
- Per-app external network `<network>--<app>` (e.g. `proxy--stiftung`) instead of the shared `proxy`.
- Public services attach with an app-scoped alias via Compose long syntax.
- Emit `traefik.docker.network=<network>--<app>` so Traefik routes over the right network when a container is on several (it resolves the backend IP only once, at discovery).
- New `traefik.container_name` setting (default `traefik`).

**State machine lifecycle**
- `EnsureAppNetworkHandler` runs **before** `compose up` (create/run/rebuild) — creates the network (required, since the override declares it external) and connects Traefik.
- `TeardownAppNetworkHandler` runs **after** `compose down`/`rm` (purge, and destroy via the nested down) — disconnects Traefik, then removes the network (Docker refuses to remove a network with an attached endpoint).
- Plain `stop` leaves the network in place to avoid start/stop churn.
- All Docker network calls are idempotent (existing network, already-connected Traefik, missing network/container tolerated); both handlers no-op for non-Traefik load balancers.

## Testing

- `cargo check`; full `scotty` lib suite (185 passed), `scotty-core` (144 passed).
- Load balancer tests including a new YAML round-trip test asserting the per-app network + alias shape.
- `cargo fmt` and `clippy` clean on all touched files.

## Notes

- The dev `apps/traefik/docker-compose.yml` still defines the shared `proxy` network as Traefik's base; that remains valid (Scotty connects Traefik to each per-app network on top), so no change was required there.

Closes #848

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFjGUm99NzcBr42ZSRepeS

---
_Generated by [Claude Code](https://claude.ai/code/session_01RFjGUm99NzcBr42ZSRepeS)_