### PR TITLE
fix: return users to the app start page after login, consolidate public URL config on api.base_url

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,7 +1,7 @@
 debug: false
 api:
     bind_address: "0.0.0.0:21342"
-    # base_url: "https://scotty.example.com"  # Public-facing URL for landing page redirects
+    # base_url: "https://scotty.example.com"  # Public-facing URL of Scotty, used for OAuth post-login and landing page redirects
     auth_mode: bearer
     create_app_max_size: "50M"
     bearer_tokens:

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -69,7 +69,6 @@ api:
     client_id: "your_client_id"
     client_secret: "your_client_secret"
     redirect_url: "http://localhost:21342/api/oauth/callback"
-    frontend_base_url: "http://localhost:21342"
 ```
 
 * `bind_address`: The address and port the server listens on.
@@ -77,7 +76,7 @@ api:
 * `create_app_max_size`: The maximum size of the uploaded files. The default
   is 50M. As the payload gets base64-encoded, the actual possible size is a
   bit smaller (by ~ 2/3)
-* `base_url`: Public-facing base URL under which Scotty itself is reachable (e.g. `"https://scotty.example.com"`). Used by the [default backend / landing page](default-backend.md) feature to tell Scotty's own domain apart from app domains and to build the redirect that lets users start a stopped app from its own URL. Optional, but should be set in any production deployment.
+* `base_url`: Public-facing base URL under which Scotty itself is reachable (e.g. `"https://scotty.example.com"`). Used for post-login OAuth redirects and by the [default backend / landing page](default-backend.md) feature to tell Scotty's own domain apart from app domains and to build the redirect that lets users start a stopped app from its own URL. **Set this in any production deployment** — when it is missing, Scotty falls back to `http://localhost:21342` and logs a warning at startup.
 * `auth_mode`: Authentication mode. Options are:
   * `"dev"`: Development mode with no authentication (uses fixed dev user)
   * `"oauth"`: Native OAuth authentication with OIDC providers (supports optional bearer token fallback for service accounts)
@@ -89,7 +88,7 @@ api:
   * `client_id`: OAuth application client ID from your OIDC provider
   * `client_secret`: OAuth application client secret from your OIDC provider
   * `redirect_url`: OAuth callback URL - must match your provider's configuration (backend endpoint)
-  * `frontend_base_url`: Base URL of your frontend application for post-authentication redirects (default: "http://localhost:21342")
+  * `frontend_base_url`: **Deprecated** — use `api.base_url` instead. Post-authentication redirects now use `api.base_url`. If this setting is still present it is used as a fallback when `api.base_url` is unset, and a deprecation warning is logged at startup; if both are set, `api.base_url` wins.
 
 **Hybrid Authentication:** When `auth_mode` is `oauth`, you can optionally configure `bearer_tokens` to enable service account access alongside OAuth for human users. This allows:
 - **Human users** authenticate via OAuth (web UI, CLI device flow)
@@ -838,6 +837,7 @@ SCOTTY__API__OAUTH__CLIENT_ID=my-local-client-id
 | `api.bearer_tokens.admin`                         | `SCOTTY__API__BEARER_TOKENS__ADMIN`                      |
 | `api.bearer_tokens.deployment`                    | `SCOTTY__API__BEARER_TOKENS__DEPLOYMENT`                 |
 | `api.bind_address`                                | `SCOTTY__API__BIND_ADDRESS`                              |
+| `api.base_url`                                    | `SCOTTY__API__BASE_URL`                                  |
 | `api.auth_mode`                                   | `SCOTTY__API__AUTH_MODE`                                 |
 | `api.dev_user_email`                              | `SCOTTY__API__DEV_USER_EMAIL`                            |
 | `api.dev_user_name`                               | `SCOTTY__API__DEV_USER_NAME`                             |
@@ -845,7 +845,7 @@ SCOTTY__API__OAUTH__CLIENT_ID=my-local-client-id
 | `api.oauth.client_id`                             | `SCOTTY__API__OAUTH__CLIENT_ID`                          |
 | `api.oauth.client_secret`                         | `SCOTTY__API__OAUTH__CLIENT_SECRET`                      |
 | `api.oauth.redirect_url`                          | `SCOTTY__API__OAUTH__REDIRECT_URL`                       |
-| `api.oauth.frontend_base_url`                     | `SCOTTY__API__OAUTH__FRONTEND_BASE_URL`                  |
+| `api.oauth.frontend_base_url` (deprecated)        | `SCOTTY__API__OAUTH__FRONTEND_BASE_URL`                  |
 | `docker.registries.example_registry.password`     | `SCOTTY__DOCKER__REGISTRIES__EXAMPLE_REGISTRY__PASSWORD` |
 | `apps.domain_suffix`                              | `SCOTTY__APPS__DOMAIN_SUFFIX`                            |
 | `load_balancer_type`                              | `SCOTTY__LOAD_BALANCER_TYPE`                             |

--- a/docs/content/default-backend.md
+++ b/docs/content/default-backend.md
@@ -94,11 +94,13 @@ Scotty uses this value to:
 * Build the `https://scotty.example.com/landing/<app>?return_url=...` redirect
   target for stopped-app domains.
 
-> If `api.base_url` is not set, Scotty falls back to `api.oauth.frontend_base_url`
-> (unless that is still the default `http://localhost:21342`). If neither is
-> configured, Scotty cannot tell its own domain apart from app domains: it logs a
-> warning and serves every request as the frontend, so **per-app domains will not
-> redirect to the landing page**. Always set `api.base_url` in production.
+> `api.base_url` is also used for post-login OAuth redirects, so the whole
+> login-and-return-to-app round trip stays on one origin. If it is not set,
+> Scotty falls back to the deprecated `api.oauth.frontend_base_url` (with a
+> deprecation warning at startup). If neither is configured, Scotty logs a
+> warning at startup, cannot tell its own domain apart from app domains, and
+> serves every request as the frontend, so **per-app domains will not redirect
+> to the landing page**. Always set `api.base_url` in production.
 
 ### 2. Configure Traefik as the default backend
 
@@ -200,8 +202,14 @@ http:
 * **App domains are served the Scotty frontend instead of redirecting.**
   `api.base_url` is probably not set (or is still the localhost default). Set it to
   Scotty's public URL. Look for the warning
-  *"Neither api.base_url nor api.oauth.frontend_base_url is configured"* in the
-  logs.
+  *"api.base_url is not configured"* in the logs.
+* **After logging in, the user lands on the app list instead of returning to the
+  app's start page.** In older releases this happened when
+  `api.oauth.frontend_base_url` pointed to a different origin than `api.base_url`
+  — the post-login redirect landed on the "wrong" origin and the stored
+  return-to-app state was invisible there. Post-login redirects now use
+  `api.base_url` directly; remove the deprecated `api.oauth.frontend_base_url`
+  setting.
 * **Stopped app domains return a gateway error instead of the landing page.**
   The catch-all router is missing or not matching. Check the Traefik dashboard for
   a `scotty-catchall` router and confirm its priority is lower than the app

--- a/docs/content/oauth-authentication.md
+++ b/docs/content/oauth-authentication.md
@@ -67,12 +67,12 @@ Configure Scotty for OAuth mode in `config/local.yaml`:
 api:
   bind_address: "0.0.0.0:21342"
   auth_mode: "oauth"
+  base_url: "http://localhost:21342"  # Public URL of Scotty, used for post-login redirects
   oauth:
     oidc_issuer_url: "https://gitlab.com"  # or your OIDC provider URL
     client_id: "your_oidc_application_id"
     client_secret: "your_oidc_application_secret"
     redirect_url: "http://localhost:21342/api/oauth/callback"
-    frontend_base_url: "http://localhost:21342"  # Base URL for frontend redirects (default: http://localhost:21342)
 ```
 
 **Provider-specific examples:**
@@ -124,21 +124,24 @@ Scotty uses two different URL configurations for OAuth:
 - **Example**: `http://localhost:21342/api/oauth/callback`
 - **Format**: Full URL to Scotty's backend `/api/oauth/callback` endpoint
 
-#### `frontend_base_url` - Frontend Application Base URL
-- **Purpose**: The base URL of your frontend application where users are redirected after OAuth completes
-- **Used by**: Scotty backend to redirect users back to the frontend with session ID
+#### `api.base_url` - Public Base URL of Scotty
+- **Purpose**: The public base URL of Scotty, where users are redirected after OAuth completes
+- **Used by**: Scotty backend to redirect users back to the web interface with a session ID (and by the [default backend / landing page](default-backend.md) feature)
 - **Must match**: The actual URL where your users access Scotty's web interface
 - **Example**: `http://localhost:21342` (development) or `https://scotty.example.com` (production)
 - **Format**: Base URL only (no path) - Scotty appends `/oauth/callback?session_id=xyz`
 
 **Production Example:**
 ```yaml
-oauth:
-  redirect_url: "https://scotty.example.com/api/oauth/callback"
-  frontend_base_url: "https://scotty.example.com"
+api:
+  base_url: "https://scotty.example.com"
+  oauth:
+    redirect_url: "https://scotty.example.com/api/oauth/callback"
 ```
 
-**Important**: Both URLs must match your production domain. Using `localhost` in production will break the OAuth flow.
+**Important**: Both URLs must match your production domain. Using `localhost` in production will break the OAuth flow — Scotty logs a warning at startup when `api.base_url` is not configured and the `localhost` default is in effect.
+
+> **Deprecated:** older releases used `api.oauth.frontend_base_url` for the post-login redirect. It still works as a fallback when `api.base_url` is unset, but logs a deprecation warning at startup; if both are set, `api.base_url` wins. Having two separately-configured URLs caused hard-to-diagnose bugs (e.g. the stopped-app landing page losing its "return to app" state when the two origins differed), which is why they were consolidated.
 
 ## OAuth Endpoints
 
@@ -245,6 +248,7 @@ Enable hybrid authentication by configuring both OAuth and bearer tokens:
 ```yaml
 api:
   auth_mode: oauth  # Enable OAuth mode
+  base_url: "http://localhost:21342"
 
   # OAuth configuration for human users
   oauth:
@@ -252,7 +256,6 @@ api:
     client_id: "your_oidc_application_id"
     client_secret: "your_oidc_application_secret"
     redirect_url: "http://localhost:21342/api/oauth/callback"
-    frontend_base_url: "http://localhost:21342"
 
   # Bearer tokens for service accounts (checked first for performance)
   bearer_tokens:

--- a/frontend/src/lib/landingResume.ts
+++ b/frontend/src/lib/landingResume.ts
@@ -1,0 +1,49 @@
+/**
+ * Landing-page resume state.
+ *
+ * When an unauthenticated user clicks "Start App" on the landing page, the
+ * intent is stored in sessionStorage so that whichever login flow follows
+ * (OAuth callback or password login) can send the user back to the landing
+ * page to start the app, instead of dropping them on the dashboard.
+ */
+
+const PENDING_START_KEY = 'scotty_landing_pending_start';
+
+export interface PendingLandingStart {
+	appName: string;
+	returnUrl: string | null;
+}
+
+function storageAvailable(): boolean {
+	return typeof sessionStorage !== 'undefined';
+}
+
+/** Remember that the user wants to start this app after logging in. */
+export function storePendingLandingStart(pending: PendingLandingStart): void {
+	if (!storageAvailable()) return;
+	sessionStorage.setItem(PENDING_START_KEY, JSON.stringify(pending));
+}
+
+/**
+ * Read and consume the pending landing start. Returns the landing page path
+ * (with `autostart=true` so the app starts without another click), or null
+ * when no start is pending. The stored entry is always removed so a stale
+ * intent cannot resurface on a later login.
+ */
+export function consumePendingLandingRedirect(): string | null {
+	if (!storageAvailable()) return null;
+	const raw = sessionStorage.getItem(PENDING_START_KEY);
+	if (!raw) return null;
+	sessionStorage.removeItem(PENDING_START_KEY);
+	try {
+		const pending = JSON.parse(raw) as PendingLandingStart;
+		if (!pending.appName) return null;
+		const params = new URLSearchParams({ autostart: 'true' });
+		if (pending.returnUrl) {
+			params.set('return_url', pending.returnUrl);
+		}
+		return `/landing/${encodeURIComponent(pending.appName)}?${params}`;
+	} catch {
+		return null;
+	}
+}

--- a/frontend/src/lib/landingResume.ts
+++ b/frontend/src/lib/landingResume.ts
@@ -7,6 +7,9 @@
  * page to start the app, instead of dropping them on the dashboard.
  */
 
+import { goto } from '$app/navigation';
+import { resolve } from '$app/paths';
+
 const PENDING_START_KEY = 'scotty_landing_pending_start';
 
 export interface PendingLandingStart {
@@ -46,4 +49,13 @@ export function consumePendingLandingRedirect(): string | null {
 	} catch {
 		return null;
 	}
+}
+
+/**
+ * Navigate to the pending landing-page app start (if any), or to the
+ * dashboard. Call after any successful login.
+ */
+export async function redirectAfterLogin(): Promise<void> {
+	// @ts-expect-error - Type-safe routing doesn't support dynamic redirect paths
+	await goto(resolve(consumePendingLandingRedirect() ?? '/dashboard'));
 }

--- a/frontend/src/routes/landing/[slug]/+page.svelte
+++ b/frontend/src/routes/landing/[slug]/+page.svelte
@@ -4,6 +4,7 @@
 	import { goto } from '$app/navigation';
 	import { isAuthenticated, authMode } from '../../../stores/sessionStore';
 	import { authService } from '../../../lib/authService';
+	import { storePendingLandingStart } from '../../../lib/landingResume';
 	import { runApp, updateAppInfo } from '../../../stores/appsStore';
 	import { monitorTask } from '../../../stores/tasksStore';
 	import {
@@ -96,13 +97,10 @@
 	async function handleStart() {
 		if (!$isAuthenticated) {
 			// Store intent to start after login
-			sessionStorage.setItem(
-				'scotty_landing_pending_start',
-				JSON.stringify({
-					appName: data.appName,
-					returnUrl: data.returnUrl
-				})
-			);
+			storePendingLandingStart({
+				appName: data.appName,
+				returnUrl: data.returnUrl
+			});
 
 			// Redirect to login -- after OAuth, user returns to /landing/[slug]
 			if ($authMode === 'oauth') {

--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -3,6 +3,7 @@
 	import { onMount } from 'svelte';
 	import { setTitle } from '../../stores/titleStore';
 	import { authService } from '../../lib/authService';
+	import { consumePendingLandingRedirect } from '../../lib/landingResume';
 	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
 
@@ -17,6 +18,14 @@
 		await checkAuthMode();
 	});
 
+	// After a successful login, resume a pending landing-page app start
+	// (stored when the user clicked "Start App" while logged out); otherwise
+	// go to the dashboard.
+	async function redirectAfterLogin() {
+		// @ts-expect-error - Type-safe routing doesn't support dynamic redirect paths
+		await goto(resolve(consumePendingLandingRedirect() ?? '/dashboard'));
+	}
+
 	async function checkAuthMode() {
 		try {
 			const result = await authService.checkAuthMode();
@@ -25,13 +34,13 @@
 
 			// Handle dev mode - redirect directly to dashboard
 			if (authMode === 'dev') {
-				await goto(resolve('/dashboard'));
+				await redirectAfterLogin();
 				return;
 			}
 
 			// Check if already authenticated and redirect
 			if (authService.isAuthenticated()) {
-				await goto(resolve('/dashboard'));
+				await redirectAfterLogin();
 				return;
 			}
 		} catch (err) {
@@ -59,7 +68,7 @@
 				if (result.redirectUrl) {
 					window.location.href = result.redirectUrl;
 				} else {
-					await goto(resolve('/dashboard'));
+					await redirectAfterLogin();
 				}
 			} else {
 				error = result.error || 'Login failed';

--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -3,9 +3,7 @@
 	import { onMount } from 'svelte';
 	import { setTitle } from '../../stores/titleStore';
 	import { authService } from '../../lib/authService';
-	import { consumePendingLandingRedirect } from '../../lib/landingResume';
-	import { goto } from '$app/navigation';
-	import { resolve } from '$app/paths';
+	import { redirectAfterLogin } from '../../lib/landingResume';
 
 	let password = '';
 	let loading = true;
@@ -17,14 +15,6 @@
 		setTitle('Login');
 		await checkAuthMode();
 	});
-
-	// After a successful login, resume a pending landing-page app start
-	// (stored when the user clicked "Start App" while logged out); otherwise
-	// go to the dashboard.
-	async function redirectAfterLogin() {
-		// @ts-expect-error - Type-safe routing doesn't support dynamic redirect paths
-		await goto(resolve(consumePendingLandingRedirect() ?? '/dashboard'));
-	}
 
 	async function checkAuthMode() {
 		try {

--- a/frontend/src/routes/oauth/callback/+page.svelte
+++ b/frontend/src/routes/oauth/callback/+page.svelte
@@ -4,6 +4,7 @@
 	import { resolve } from '$app/paths';
 	import { page } from '$app/stores';
 	import { authService } from '../../../lib/authService';
+	import { consumePendingLandingRedirect } from '../../../lib/landingResume';
 
 	let loading = true;
 	let error: string | null = null;
@@ -43,32 +44,11 @@
 				const { loadUserPermissions } = await import('../../../stores/permissionStore');
 				await loadUserPermissions();
 
-				// Check if we came from the landing page flow.
-				// The sessionStorage key is read-then-removed here so that the
-				// landing page receives the autostart=true query param instead of
-				// re-reading from sessionStorage. This avoids a stale entry if the
-				// user later visits the landing page for a different app.
-				const pendingStart = sessionStorage.getItem('scotty_landing_pending_start');
-				if (pendingStart) {
-					try {
-						const pending = JSON.parse(pendingStart);
-						sessionStorage.removeItem('scotty_landing_pending_start');
-						// eslint-disable-next-line svelte/prefer-svelte-reactivity -- non-reactive context
-						const params = new URLSearchParams({ autostart: 'true' });
-						if (pending.returnUrl) {
-							params.set('return_url', pending.returnUrl);
-						}
-						await goto(
-							resolve(`/landing/${encodeURIComponent(pending.appName)}?${params}`)
-						);
-						return;
-					} catch {
-						sessionStorage.removeItem('scotty_landing_pending_start');
-					}
-				}
-
-				// Default: redirect to dashboard
-				await goto(resolve('/dashboard'));
+				// If we came from the landing page flow, return there so the
+				// app is started; otherwise go to the dashboard.
+				const pendingRedirect = consumePendingLandingRedirect();
+				// @ts-expect-error - Type-safe routing doesn't support dynamic redirect paths
+				await goto(resolve(pendingRedirect ?? '/dashboard'));
 			} else {
 				error = result.error || 'Authentication failed';
 				loading = false;

--- a/frontend/src/routes/oauth/callback/+page.svelte
+++ b/frontend/src/routes/oauth/callback/+page.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { goto } from '$app/navigation';
-	import { resolve } from '$app/paths';
 	import { page } from '$app/stores';
 	import { authService } from '../../../lib/authService';
-	import { consumePendingLandingRedirect } from '../../../lib/landingResume';
+	import { redirectAfterLogin } from '../../../lib/landingResume';
 
 	let loading = true;
 	let error: string | null = null;
@@ -46,9 +44,7 @@
 
 				// If we came from the landing page flow, return there so the
 				// app is started; otherwise go to the dashboard.
-				const pendingRedirect = consumePendingLandingRedirect();
-				// @ts-expect-error - Type-safe routing doesn't support dynamic redirect paths
-				await goto(resolve(pendingRedirect ?? '/dashboard'));
+				await redirectAfterLogin();
 			} else {
 				error = result.error || 'Authentication failed';
 				loading = false;

--- a/scotty-core/src/settings/api_server.rs
+++ b/scotty-core/src/settings/api_server.rs
@@ -161,14 +161,29 @@ impl ApiServer {
             }
         }
 
-        if self.is_using_default_base_url() {
-            warnings.push(format!(
-                "api.base_url is not configured — falling back to the default '{}'. \
-                 OAuth logins and the stopped-app landing page will not work correctly \
-                 unless api.base_url is set to Scotty's public URL \
-                 (e.g. 'https://scotty.example.com').",
-                DEFAULT_BASE_URL
-            ));
+        match self.configured_base_url() {
+            None => {
+                warnings.push(format!(
+                    "api.base_url is not configured — falling back to the default '{}'. \
+                     OAuth logins and the stopped-app landing page will not work correctly \
+                     unless api.base_url is set to Scotty's public URL \
+                     (e.g. 'https://scotty.example.com').",
+                    DEFAULT_BASE_URL
+                ));
+            }
+            Some(configured) => {
+                let parses_with_host = url::Url::parse(&configured)
+                    .map(|url| url.host_str().is_some())
+                    .unwrap_or(false);
+                if !parses_with_host {
+                    warnings.push(format!(
+                        "the configured public base URL ('{}') is not a valid absolute URL \
+                         (missing 'https://' scheme?). OAuth redirects and the stopped-app \
+                         landing page will not work until it is fixed.",
+                        configured
+                    ));
+                }
+            }
         }
 
         warnings
@@ -292,6 +307,15 @@ mod tests {
         assert_eq!(warnings.len(), 1);
         assert!(warnings[0].contains("differs"));
         assert!(warnings[0].contains("api.base_url wins"));
+    }
+
+    #[test]
+    fn test_warning_for_malformed_base_url() {
+        // Missing scheme: parses as a relative/hostless URL and cannot be
+        // used for redirects or own-domain detection.
+        let warnings = api_server(Some("scotty.example.com"), None).base_url_config_warnings();
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("not a valid absolute URL"));
     }
 
     #[test]

--- a/scotty-core/src/settings/api_server.rs
+++ b/scotty-core/src/settings/api_server.rs
@@ -33,10 +33,13 @@ pub struct OAuthSettings {
     pub client_secret: Option<SecretString>,
     #[serde(default = "default_device_flow_enabled")]
     pub device_flow_enabled: bool,
-    /// Frontend base URL for OAuth callback redirects
-    /// Example: "http://localhost:21342" or "https://scotty.example.com"
-    #[serde(default = "default_frontend_base_url")]
-    pub frontend_base_url: String,
+    /// DEPRECATED: use `api.base_url` instead.
+    ///
+    /// Frontend base URL for OAuth callback redirects. Kept only for backward
+    /// compatibility: when `api.base_url` is unset, this value is used as a
+    /// fallback and a deprecation warning is logged at startup.
+    #[serde(default)]
+    pub frontend_base_url: Option<String>,
 }
 
 impl Default for OAuthSettings {
@@ -48,7 +51,7 @@ impl Default for OAuthSettings {
             client_id: None,
             client_secret: None,
             device_flow_enabled: default_device_flow_enabled(),
-            frontend_base_url: default_frontend_base_url(),
+            frontend_base_url: None,
         }
     }
 }
@@ -86,11 +89,90 @@ fn default_device_flow_enabled() -> bool {
     true
 }
 
-/// Default frontend base URL used when no explicit configuration is provided.
-pub const DEFAULT_FRONTEND_BASE_URL: &str = "http://localhost:21342";
+/// Default public base URL used when neither `api.base_url` nor the
+/// deprecated `api.oauth.frontend_base_url` is configured.
+pub const DEFAULT_BASE_URL: &str = "http://localhost:21342";
 
-fn default_frontend_base_url() -> String {
-    DEFAULT_FRONTEND_BASE_URL.to_string()
+impl ApiServer {
+    /// Resolve the public base URL of this Scotty installation.
+    ///
+    /// Every feature that needs Scotty's public URL (OAuth post-login
+    /// redirects, the stopped-app landing page, own-domain detection) must go
+    /// through this single resolution so they can never disagree on the
+    /// origin. Resolution order: `api.base_url`, then the deprecated
+    /// `api.oauth.frontend_base_url`, then [`DEFAULT_BASE_URL`]. Empty values
+    /// count as unset; a trailing slash is stripped.
+    pub fn public_base_url(&self) -> String {
+        self.configured_base_url()
+            .unwrap_or_else(|| DEFAULT_BASE_URL.to_string())
+    }
+
+    /// The explicitly configured public base URL, if any.
+    pub fn configured_base_url(&self) -> Option<String> {
+        [self.base_url.as_deref(), self.frontend_base_url()]
+            .into_iter()
+            .flatten()
+            .map(str::trim)
+            .find(|url| !url.is_empty())
+            .map(|url| url.trim_end_matches('/').to_string())
+    }
+
+    /// Whether no public base URL is configured and the localhost default is
+    /// in effect.
+    pub fn is_using_default_base_url(&self) -> bool {
+        self.configured_base_url().is_none()
+    }
+
+    fn frontend_base_url(&self) -> Option<&str> {
+        self.oauth.frontend_base_url.as_deref()
+    }
+
+    /// Configuration problems around the public base URL, as human-readable
+    /// warnings to be logged at startup.
+    pub fn base_url_config_warnings(&self) -> Vec<String> {
+        let mut warnings = Vec::new();
+
+        let frontend = self
+            .frontend_base_url()
+            .map(str::trim)
+            .filter(|url| !url.is_empty());
+        let base = self
+            .base_url
+            .as_deref()
+            .map(str::trim)
+            .filter(|url| !url.is_empty());
+
+        if let Some(frontend) = frontend {
+            match base {
+                Some(base) if base.trim_end_matches('/') != frontend.trim_end_matches('/') => {
+                    warnings.push(format!(
+                        "api.oauth.frontend_base_url ('{}') differs from api.base_url ('{}'). \
+                         api.base_url wins; remove the deprecated api.oauth.frontend_base_url \
+                         setting to silence this warning.",
+                        frontend, base
+                    ));
+                }
+                _ => {
+                    warnings.push(
+                        "api.oauth.frontend_base_url is deprecated; set api.base_url instead."
+                            .to_string(),
+                    );
+                }
+            }
+        }
+
+        if self.is_using_default_base_url() {
+            warnings.push(format!(
+                "api.base_url is not configured — falling back to the default '{}'. \
+                 OAuth logins and the stopped-app landing page will not work correctly \
+                 unless api.base_url is set to Scotty's public URL \
+                 (e.g. 'https://scotty.example.com').",
+                DEFAULT_BASE_URL
+            ));
+        }
+
+        warnings
+    }
 }
 
 impl Default for ApiServer {
@@ -127,4 +209,99 @@ where
 
     let num: usize = num_part.parse().map_err(serde::de::Error::custom)?;
     Ok(num * multiplier)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn api_server(base_url: Option<&str>, frontend_base_url: Option<&str>) -> ApiServer {
+        let mut api = ApiServer {
+            base_url: base_url.map(str::to_string),
+            ..Default::default()
+        };
+        api.oauth = OAuthSettings {
+            frontend_base_url: frontend_base_url.map(str::to_string),
+            ..Default::default()
+        };
+        api
+    }
+
+    #[test]
+    fn test_public_base_url_prefers_base_url() {
+        let api = api_server(
+            Some("https://scotty.example.com"),
+            Some("https://other.example.com"),
+        );
+        assert_eq!(api.public_base_url(), "https://scotty.example.com");
+        assert!(!api.is_using_default_base_url());
+    }
+
+    #[test]
+    fn test_public_base_url_falls_back_to_deprecated_frontend_base_url() {
+        let api = api_server(None, Some("https://legacy.example.com"));
+        assert_eq!(api.public_base_url(), "https://legacy.example.com");
+        assert!(!api.is_using_default_base_url());
+    }
+
+    #[test]
+    fn test_public_base_url_defaults_to_localhost() {
+        let api = api_server(None, None);
+        assert_eq!(api.public_base_url(), DEFAULT_BASE_URL);
+        assert!(api.is_using_default_base_url());
+    }
+
+    #[test]
+    fn test_public_base_url_treats_empty_as_unset_and_strips_trailing_slash() {
+        let api = api_server(Some("  "), Some("https://legacy.example.com/"));
+        assert_eq!(api.public_base_url(), "https://legacy.example.com");
+
+        let api = api_server(Some("https://scotty.example.com/"), None);
+        assert_eq!(api.public_base_url(), "https://scotty.example.com");
+    }
+
+    #[test]
+    fn test_warnings_when_nothing_configured() {
+        let warnings = api_server(None, None).base_url_config_warnings();
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("api.base_url is not configured"));
+    }
+
+    #[test]
+    fn test_no_warnings_when_base_url_configured() {
+        let warnings =
+            api_server(Some("https://scotty.example.com"), None).base_url_config_warnings();
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn test_deprecation_warning_for_frontend_base_url() {
+        let warnings =
+            api_server(None, Some("https://scotty.example.com")).base_url_config_warnings();
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("deprecated"));
+    }
+
+    #[test]
+    fn test_conflict_warning_when_both_set_and_different() {
+        let warnings = api_server(
+            Some("https://scotty.example.com"),
+            Some("http://scotty.example.com"),
+        )
+        .base_url_config_warnings();
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("differs"));
+        assert!(warnings[0].contains("api.base_url wins"));
+    }
+
+    #[test]
+    fn test_deprecation_warning_when_both_set_and_equal() {
+        let warnings = api_server(
+            Some("https://scotty.example.com"),
+            Some("https://scotty.example.com/"),
+        )
+        .base_url_config_warnings();
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("deprecated"));
+    }
 }

--- a/scotty/src/api/rest/handlers/landing.rs
+++ b/scotty/src/api/rest/handlers/landing.rs
@@ -9,7 +9,6 @@ use crate::app_state::SharedAppState;
 use crate::static_files::serve_embedded_file;
 
 use scotty_core::apps::app_data::AppStatus;
-use scotty_core::settings::api_server::DEFAULT_FRONTEND_BASE_URL;
 
 /// Build a Response with no-cache headers to prevent browsers and proxies
 /// from caching redirect or error responses for stopped apps.
@@ -156,19 +155,11 @@ pub async fn landing_or_frontend_handler(
 
 /// Check if the given hostname matches Scotty's own domain.
 fn is_scotty_domain(state: &SharedAppState, hostname: &str) -> bool {
-    // Check against configured base_url
-    if let Some(base_url) = &state.settings.api.base_url {
-        if let Ok(url) = Url::parse(base_url) {
+    if let Some(base_url) = state.settings.api.configured_base_url() {
+        if let Ok(url) = Url::parse(&base_url) {
             if let Some(host) = url.host_str() {
                 return hostname.eq_ignore_ascii_case(host);
             }
-        }
-    }
-
-    // Fallback: check against oauth frontend_base_url
-    if let Ok(url) = Url::parse(&state.settings.api.oauth.frontend_base_url) {
-        if let Some(host) = url.host_str() {
-            return hostname.eq_ignore_ascii_case(host);
         }
     }
 
@@ -177,9 +168,9 @@ fn is_scotty_domain(state: &SharedAppState, hostname: &str) -> bool {
     static WARN_UNCONFIGURED: Once = Once::new();
     WARN_UNCONFIGURED.call_once(|| {
         tracing::warn!(
-            "Neither api.base_url nor api.oauth.frontend_base_url is configured. \
-             All requests will be served as Scotty frontend — \
-             per-app domains will not redirect to the landing page."
+            "api.base_url is not configured. All requests will be served as \
+             Scotty frontend — per-app domains will not redirect to the \
+             landing page."
         );
     });
     true
@@ -187,20 +178,7 @@ fn is_scotty_domain(state: &SharedAppState, hostname: &str) -> bool {
 
 /// Extract the base URL for constructing redirect targets.
 fn get_scotty_base_url(state: &SharedAppState) -> Option<String> {
-    if let Some(base_url) = &state.settings.api.base_url {
-        if !base_url.is_empty() {
-            return Some(base_url.clone());
-        }
-    }
-
-    // Fallback to oauth frontend_base_url, but skip the default localhost value
-    // since it indicates no explicit configuration was provided.
-    let frontend_url = &state.settings.api.oauth.frontend_base_url;
-    if !frontend_url.is_empty() && frontend_url != DEFAULT_FRONTEND_BASE_URL {
-        return Some(frontend_url.clone());
-    }
-
-    None
+    state.settings.api.configured_base_url()
 }
 
 #[cfg(test)]

--- a/scotty/src/api/rest/handlers/landing.rs
+++ b/scotty/src/api/rest/handlers/landing.rs
@@ -155,30 +155,53 @@ pub async fn landing_or_frontend_handler(
 
 /// Check if the given hostname matches Scotty's own domain.
 fn is_scotty_domain(state: &SharedAppState, hostname: &str) -> bool {
-    if let Some(base_url) = state.settings.api.configured_base_url() {
-        if let Ok(url) = Url::parse(&base_url) {
-            if let Some(host) = url.host_str() {
-                return hostname.eq_ignore_ascii_case(host);
-            }
+    let Some(base_url) = state.settings.api.configured_base_url() else {
+        // Nothing configured: assume it's Scotty (don't redirect).
+        // Log a warning once so operators notice the missing configuration.
+        static WARN_UNCONFIGURED: Once = Once::new();
+        WARN_UNCONFIGURED.call_once(|| {
+            tracing::warn!(
+                "api.base_url is not configured. All requests will be served as \
+                 Scotty frontend — per-app domains will not redirect to the \
+                 landing page."
+            );
+        });
+        return true;
+    };
+
+    match Url::parse(&base_url).ok().and_then(|url| {
+        url.host_str()
+            .map(|host| hostname.eq_ignore_ascii_case(host))
+    }) {
+        Some(matches) => matches,
+        None => {
+            // Configured but not a parseable absolute URL: we cannot tell
+            // Scotty's own domain apart from app domains. Serve everything as
+            // Scotty rather than 404-ing its own UI; the startup warning from
+            // base_url_config_warnings() points the operator at the broken
+            // value.
+            static WARN_MALFORMED: Once = Once::new();
+            WARN_MALFORMED.call_once(|| {
+                tracing::warn!(
+                    "the configured public base URL ('{}') is not a valid absolute \
+                     URL. All requests will be served as Scotty frontend — per-app \
+                     domains will not redirect to the landing page.",
+                    base_url
+                );
+            });
+            true
         }
     }
-
-    // If nothing is configured, assume it's Scotty (don't redirect).
-    // Log a warning once so operators notice the missing configuration.
-    static WARN_UNCONFIGURED: Once = Once::new();
-    WARN_UNCONFIGURED.call_once(|| {
-        tracing::warn!(
-            "api.base_url is not configured. All requests will be served as \
-             Scotty frontend — per-app domains will not redirect to the \
-             landing page."
-        );
-    });
-    true
 }
 
-/// Extract the base URL for constructing redirect targets.
+/// Extract the base URL for constructing redirect targets. Returns None for
+/// unparseable values so we never emit a broken Location header.
 fn get_scotty_base_url(state: &SharedAppState) -> Option<String> {
-    state.settings.api.configured_base_url()
+    state.settings.api.configured_base_url().filter(|base_url| {
+        Url::parse(base_url)
+            .map(|url| url.host_str().is_some())
+            .unwrap_or(false)
+    })
 }
 
 #[cfg(test)]

--- a/scotty/src/main.rs
+++ b/scotty/src/main.rs
@@ -81,6 +81,12 @@ async fn main() -> anyhow::Result<()> {
     let app_state = app_state::AppState::new().await?;
     init_telemetry::init_telemetry_and_tracing(&app_state.clone().settings.telemetry)?;
 
+    // Surface base-url misconfiguration early: a missing or conflicting
+    // public base URL silently breaks OAuth redirects and the landing page.
+    for warning in app_state.settings.api.base_url_config_warnings() {
+        warn!("⚠️  {}", warning);
+    }
+
     // Warn if running in development mode
     if matches!(app_state.settings.api.auth_mode, AuthMode::Development) {
         let dev_user = app_state

--- a/scotty/src/oauth/handlers.rs
+++ b/scotty/src/oauth/handlers.rs
@@ -429,10 +429,11 @@ pub async fn handle_oauth_callback(
                         if let Some(frontend_callback) = &session.frontend_callback_url {
                             format!("{}?session_id={}", frontend_callback, oauth_session_id)
                         } else {
-                            // Fallback to configured frontend base URL
+                            // Fallback to the public base URL (api.base_url)
                             format!(
                                 "{}/oauth/callback?session_id={}",
-                                app_state.settings.api.oauth.frontend_base_url, oauth_session_id
+                                app_state.settings.api.public_base_url(),
+                                oauth_session_id
                             )
                         };
 


### PR DESCRIPTION
## Summary

Fixes the reported bug where, after logging in from a stopped app's landing page, users were dropped on the app list (dashboard) instead of returning to the app start/status page — in both bearer and OAuth mode. Also adds the missing documentation for the "Scotty as Traefik default backend" feature.

### Root causes

- **OAuth mode:** the landing page stores its "return to app" intent in `sessionStorage`, which is per-origin. The landing page lives on the origin from `api.base_url`, but the post-login redirect went to `api.oauth.frontend_base_url`. When the two settings didn't share the exact same origin, the stored intent was invisible after login and the OAuth callback silently fell back to the dashboard.
- **Bearer mode:** the `/login` page never checked the stored intent at all and always redirected to the dashboard after a successful login.

### Changes

**`feat(config)`: consolidate public URL config on `api.base_url`**
- Deprecate `api.oauth.frontend_base_url`; it remains a backward-compatible fallback when `api.base_url` is unset.
- All consumers (OAuth post-login redirect, landing page redirects, own-domain detection) now resolve the public URL through a single `ApiServer::public_base_url()` accessor, so they can never disagree on the origin again.
- Startup warnings: when the `http://localhost:21342` default is in effect, when the deprecated setting is used, and (loudly) when both settings are present but differ. Covered by unit tests and verified against a running server in all four configurations.

**`fix(frontend)`: resume landing-page app start after password login**
- Extract the pending-start handling into a shared `lib/landingResume.ts` helper and use it in both the OAuth callback and all login-page exit points (password login, dev mode, already authenticated). The stored intent is always consumed so a stale entry cannot resurface on a later login.

**`docs`: document the default backend / landing page feature**
- New dedicated docs page (Traefik catch-all router via labels and file provider, `api.base_url`, per-app-status behaviour, security notes, troubleshooting), added to the docs menu and cross-linked from the configuration reference; OAuth docs updated for the deprecation.

### Verification

- Both login flows verified end-to-end in headless Chromium against the real production frontend build with a mocked backend + fake OIDC provider: landing → login (password / OAuth round trip) → back on `/landing/<app>?autostart=true` → app starts → redirect to the original app URL. The OAuth origin-mismatch failure was reproduced the same way before the fix.
- Full cargo test suite, clippy, `bun run lint`, and `bun run check` pass (no new type errors; the pre-existing ones stem from uncommitted generated TS bindings).

### Notes for operators

Set `api.base_url` to Scotty's public URL and remove `api.oauth.frontend_base_url`. Existing configs keep working — a deprecation warning is logged, and `api.base_url` wins on conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GABDN2A9GSr7GuJSCg57sG

---
_Generated by [Claude Code](https://claude.ai/code/session_01GABDN2A9GSr7GuJSCg57sG)_