### PR TITLE
fix: remove redundant references in format macro arguments

### DIFF
--- a/scotty-core/src/apps/app_data/settings.rs
+++ b/scotty-core/src/apps/app_data/settings.rs
@@ -111,8 +111,8 @@ impl AppSettings {
             if !found {
                 return Err(anyhow::anyhow!(
                     "Service {} for custom domain {} not found",
-                    &custom_domain.service,
-                    &custom_domain.domain
+                    custom_domain.service,
+                    custom_domain.domain
                 ));
             }
         }

--- a/scotty-core/src/settings/app_blueprint.rs
+++ b/scotty-core/src/settings/app_blueprint.rs
@@ -161,7 +161,7 @@ pub struct AppBlueprintList {
 // The error type has to implement Display
 impl std::fmt::Display for AppBlueprintValidationError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(formatter, "AppBlueprint didnt validate: {}", &self.msg)
+        write!(formatter, "AppBlueprint didnt validate: {}", self.msg)
     }
 }
 
@@ -196,10 +196,7 @@ impl AppBlueprint {
         {
             if !self.required_services.contains(public_service) {
                 return Err(AppBlueprintValidationError {
-                    msg: format!(
-                        "Public service {} not in required services",
-                        &public_service
-                    ),
+                    msg: format!("Public service {} not in required services", public_service),
                 });
             }
         }
@@ -211,7 +208,7 @@ impl AppBlueprint {
                     return Err(AppBlueprintValidationError {
                         msg: format!(
                             "service {} required for action {:?} not in required services",
-                            &service, &action_name
+                            service, action_name
                         ),
                     });
                 }

--- a/scotty-types/src/lib.rs
+++ b/scotty-types/src/lib.rs
@@ -642,7 +642,7 @@ impl fmt::Display for WebSocketMessage {
                 let data_preview = if data.data.len() > 50 {
                     format!("{}... ({} bytes)", &data.data[..50], data.data.len())
                 } else {
-                    format!("{} ({} bytes)", &data.data, data.data.len())
+                    format!("{} ({} bytes)", data.data, data.data.len())
                 };
                 write!(
                     f,

--- a/scotty/src/docker/loadbalancer/haproxy.rs
+++ b/scotty/src/docker/loadbalancer/haproxy.rs
@@ -103,7 +103,7 @@ impl LoadBalancerImpl for HaproxyLoadBalancer {
                 "VHOST".into(),
                 service.get_domains(&settings.domain).join(" "),
             );
-            environment.insert("VPORT".into(), format!("{}", &service.port));
+            environment.insert("VPORT".into(), format!("{}", service.port));
 
             if let Some((basic_auth_user, basic_auth_pass)) = &settings.basic_auth {
                 environment.insert("HTTP_AUTH_USER".into(), basic_auth_user.clone());

--- a/scotty/src/docker/loadbalancer/traefik.rs
+++ b/scotty/src/docker/loadbalancer/traefik.rs
@@ -113,7 +113,7 @@ impl LoadBalancerImpl for TraefikLoadBalancer {
             if service_config.environment.is_none() {
                 service_config.environment = Some(HashMap::new());
             }
-            let service_name = format!("{}--{}", &service.service, &app_name);
+            let service_name = format!("{}--{}", service.service, app_name);
 
             // Attach the public service to its project `default` network and to
             // the per-app proxy network. On the proxy network we set an explicit
@@ -144,13 +144,13 @@ impl LoadBalancerImpl for TraefikLoadBalancer {
             let domains = service.get_domains(&settings.domain);
             for (idx, domain) in domains.iter().enumerate() {
                 labels.insert(
-                    format!("traefik.http.routers.{}-{}.rule", &service_name, idx),
+                    format!("traefik.http.routers.{}-{}.rule", service_name, idx),
                     format!("Host(`{domain}`)"),
                 );
 
                 if global_settings.traefik.use_tls {
                     labels.insert(
-                        format!("traefik.http.routers.{}-{}.tls", &service_name, idx),
+                        format!("traefik.http.routers.{}-{}.tls", service_name, idx),
                         "true".to_string(),
                     );
 
@@ -158,7 +158,7 @@ impl LoadBalancerImpl for TraefikLoadBalancer {
                         labels.insert(
                             format!(
                                 "traefik.http.routers.{}-{}.tls.certresolver",
-                                &service_name, idx
+                                service_name, idx
                             ),
                             certresolver.clone(),
                         );
@@ -169,26 +169,26 @@ impl LoadBalancerImpl for TraefikLoadBalancer {
             labels.insert(
                 format!(
                     "traefik.http.services.{}.loadbalancer.server.port",
-                    &service_name,
+                    service_name,
                 ),
-                format!("{}", &service.port),
+                format!("{}", service.port),
             );
 
             let mut middlewares = vec![];
 
             if let Some((basic_auth_user, basic_auth_pass)) = &settings.basic_auth {
-                let middleware_name = format!("{}--{}", &service_name, "basic-auth");
+                let middleware_name = format!("{}--{}", service_name, "basic-auth");
                 labels.insert(
                     format!(
                         "traefik.http.middlewares.{}.basicauth.users",
-                        &middleware_name
+                        middleware_name
                     ),
                     format!("{}:{}", basic_auth_user, htpasswd(basic_auth_pass, true)?),
                 );
                 labels.insert(
                     format!(
                         "traefik.http.middlewares.{}.basicauth.removeheader",
-                        &middleware_name
+                        middleware_name
                     ),
                     "true".to_string(),
                 );
@@ -197,11 +197,11 @@ impl LoadBalancerImpl for TraefikLoadBalancer {
             }
 
             if settings.disallow_robots {
-                let middleware_name = format!("{}--{}", &service_name, "robots");
+                let middleware_name = format!("{}--{}", service_name, "robots");
                 labels.insert(
                     format!(
                         "traefik.http.middlewares.{}.headers.customresponseheaders.X-Robots-Tag",
-                        &middleware_name
+                        middleware_name
                     ),
                     ROBOTS_HEADER_VALUE.to_string(),
                 );
@@ -217,7 +217,7 @@ impl LoadBalancerImpl for TraefikLoadBalancer {
             // Connect the middleware to the router
             for (idx, _domain) in domains.iter().enumerate() {
                 labels.insert(
-                    format!("traefik.http.routers.{}-{}.middlewares", &service_name, idx),
+                    format!("traefik.http.routers.{}-{}.middlewares", service_name, idx),
                     middlewares.join(","),
                 );
             }

--- a/scotty/src/docker/state_machine_handlers/run_docker_compose_handler.rs
+++ b/scotty/src/docker/state_machine_handlers/run_docker_compose_handler.rs
@@ -37,7 +37,7 @@ where
                 .collect::<Vec<&str>>()
                 .as_slice(),
             &self.env,
-            &format!("docker-compose {}", &self.command.join(" ")),
+            &format!("docker-compose {}", self.command.join(" ")),
         )
         .await?;
 

--- a/scotty/src/docker/state_machine_handlers/run_docker_login_handler.rs
+++ b/scotty/src/docker/state_machine_handlers/run_docker_login_handler.rs
@@ -55,7 +55,7 @@ where
             "docker",
             &args,
             &SecretHashMap::new(),
-            &format!("Log into registry {}", &registry.registry),
+            &format!("Log into registry {}", registry.registry),
         )
         .await?;
 

--- a/scotty/src/docker/state_machine_handlers/run_post_actions_handler.rs
+++ b/scotty/src/docker/state_machine_handlers/run_post_actions_handler.rs
@@ -158,7 +158,7 @@ where
                 "docker-compose",
                 &args,
                 &environment,
-                &format!("action {:?} on service {}", &self.action, service),
+                &format!("action {:?} on service {}", self.action, service),
             )
             .await?;
         }

--- a/scotty/src/http.rs
+++ b/scotty/src/http.rs
@@ -40,7 +40,7 @@ pub async fn setup_http_server(
         app
     };
 
-    println!("🚀 API-Server starting at http://{}", &bind_address);
+    println!("🚀 API-Server starting at http://{}", bind_address);
     let listener = tokio::net::TcpListener::bind(&bind_address).await.unwrap();
 
     let stop_flag = app_state.clone().stop_flag.clone();

--- a/scotty/src/main.rs
+++ b/scotty/src/main.rs
@@ -68,7 +68,7 @@ async fn main() -> anyhow::Result<()> {
     match cli.command.as_ref().unwrap_or(&Commands::Run) {
         Commands::Config => {
             let app_state = app_state::AppState::new_for_config_only().await?;
-            println!("{:#?}", &app_state.settings);
+            println!("{:#?}", app_state.settings);
             return Ok(());
         }
         Commands::Run => {

--- a/scotty/src/notification/gitlab.rs
+++ b/scotty/src/notification/gitlab.rs
@@ -74,7 +74,7 @@ impl NotificationImpl for NotifyGitlab {
         let comment = MergeRequestComment {
             body: format!(
                 "**{}**\n\nUrls:\n{}",
-                &msg.message,
+                msg.message,
                 msg.urls
                     .iter()
                     .map(|u| { format!("- [{u}]({u})") })

--- a/scottyctl/src/api.rs
+++ b/scottyctl/src/api.rs
@@ -132,20 +132,20 @@ pub async fn get_or_post(
             if err.is_client_error() {
                 Err(anyhow::anyhow!(
                     "Client error calling scotty API at {}: {}",
-                    &url,
+                    url,
                     err
                 ))
             } else {
                 Err(anyhow::anyhow!(
                     "Failed to call scotty API at {}: {}",
-                    &url,
+                    url,
                     err
                 ))
             }
         }
         Err(RetryError::ExhaustedRetries { error, attempts }) => Err(anyhow::anyhow!(
             "Failed to call scotty API at {} after {} retries: {}",
-            &url,
+            url,
             attempts,
             error
         )),
@@ -254,7 +254,7 @@ pub async fn wait_for_task(
         // Poll for task completion status
         let mut done = false;
         while !done {
-            let result = get(server, &format!("task/{}", &context.task.id)).await?;
+            let result = get(server, &format!("task/{}", context.task.id)).await?;
             let task: TaskDetails =
                 serde_json::from_value(result).context("Failed to parse task")?;
 
@@ -319,7 +319,7 @@ pub async fn wait_for_task(
 
         let mut done = false;
         while !done {
-            let result = get(server, &format!("task/{}", &context.task.id)).await?;
+            let result = get(server, &format!("task/{}", context.task.id)).await?;
             let task: TaskDetails =
                 serde_json::from_value(result).context("Failed to parse task")?;
 

--- a/scottyctl/src/commands/apps/actions.rs
+++ b/scottyctl/src/commands/apps/actions.rs
@@ -21,8 +21,8 @@ pub async fn run_custom_action(context: &AppContext, cmd: &ActionCommand) -> any
     let ui = context.ui();
     ui.new_status_line(format!(
         "Running custom action {} on app {}...",
-        &cmd.action_name.yellow(),
-        &cmd.app_name.yellow()
+        cmd.action_name.yellow(),
+        cmd.app_name.yellow()
     ));
     ui.run(async || {
         // Connect WebSocket before starting the task
@@ -35,7 +35,7 @@ pub async fn run_custom_action(context: &AppContext, cmd: &ActionCommand) -> any
 
         let result = get_or_post(
             context.server(),
-            &format!("apps/{}/actions", &cmd.app_name),
+            &format!("apps/{}/actions", cmd.app_name),
             "POST",
             Some(payload),
         )
@@ -50,8 +50,8 @@ pub async fn run_custom_action(context: &AppContext, cmd: &ActionCommand) -> any
 
         ui.success(format!(
             "Custom action {} completed successfully for app {}",
-            &cmd.action_name.yellow(),
-            &cmd.app_name.yellow()
+            cmd.action_name.yellow(),
+            cmd.app_name.yellow()
         ));
 
         format_app_info(&app_data)
@@ -67,12 +67,12 @@ pub async fn list_custom_actions(
     let ui = context.ui();
     ui.new_status_line(format!(
         "Getting custom actions for app {}...",
-        &cmd.app_name.yellow()
+        cmd.app_name.yellow()
     ));
     ui.run(async || {
         let result = get(
             context.server(),
-            &format!("apps/{}/custom-actions", &cmd.app_name),
+            &format!("apps/{}/custom-actions", cmd.app_name),
         )
         .await?;
 
@@ -123,13 +123,13 @@ pub async fn get_custom_action(context: &AppContext, cmd: &ActionGetCommand) -> 
     let ui = context.ui();
     ui.new_status_line(format!(
         "Getting custom action '{}' for app '{}'...",
-        &cmd.action_name.yellow(),
-        &cmd.app_name.yellow()
+        cmd.action_name.yellow(),
+        cmd.app_name.yellow()
     ));
     ui.run(async || {
         let result = get(
             context.server(),
-            &format!("apps/{}/custom-actions/{}", &cmd.app_name, &cmd.action_name),
+            &format!("apps/{}/custom-actions/{}", cmd.app_name, cmd.action_name),
         )
         .await?;
 
@@ -156,8 +156,8 @@ pub async fn create_custom_action(
     let ui = context.ui();
     ui.new_status_line(format!(
         "Creating custom action '{}' for app '{}'...",
-        &cmd.action_name.yellow(),
-        &cmd.app_name.yellow()
+        cmd.action_name.yellow(),
+        cmd.app_name.yellow()
     ));
 
     // Parse commands from SERVICE:COMMAND format
@@ -190,7 +190,7 @@ pub async fn create_custom_action(
 
     let result = post(
         context.server(),
-        &format!("apps/{}/custom-actions", &cmd.app_name),
+        &format!("apps/{}/custom-actions", cmd.app_name),
         payload,
     )
     .await?;
@@ -223,13 +223,13 @@ pub async fn delete_custom_action(
     let ui = context.ui();
     ui.new_status_line(format!(
         "Deleting custom action '{}' from app '{}'...",
-        &cmd.action_name.yellow(),
-        &cmd.app_name.yellow()
+        cmd.action_name.yellow(),
+        cmd.app_name.yellow()
     ));
 
     delete(
         context.server(),
-        &format!("apps/{}/custom-actions/{}", &cmd.app_name, &cmd.action_name),
+        &format!("apps/{}/custom-actions/{}", cmd.app_name, cmd.action_name),
         None::<serde_json::Value>,
     )
     .await?;

--- a/scottyctl/src/commands/apps/lifecycle.rs
+++ b/scottyctl/src/commands/apps/lifecycle.rs
@@ -33,11 +33,11 @@ pub async fn purge_app(context: &AppContext, cmd: &PurgeCommand) -> anyhow::Resu
 /// Adopt an existing app into Scotty management
 pub async fn adopt_app(context: &AppContext, cmd: &AdoptCommand) -> anyhow::Result<()> {
     let ui = context.ui();
-    ui.new_status_line(format!("Adopting app {}...", &cmd.app_name));
+    ui.new_status_line(format!("Adopting app {}...", cmd.app_name));
     ui.run(async || {
-        let result = get(context.server(), &format!("apps/adopt/{}", &cmd.app_name)).await?;
+        let result = get(context.server(), &format!("apps/adopt/{}", cmd.app_name)).await?;
         let app_data: AppData = serde_json::from_value(result)?;
-        ui.success(format!("App {} adopted successfully", &cmd.app_name));
+        ui.success(format!("App {} adopted successfully", cmd.app_name));
         format_app_info(&app_data)
     })
     .await
@@ -46,22 +46,22 @@ pub async fn adopt_app(context: &AppContext, cmd: &AdoptCommand) -> anyhow::Resu
 /// Destroy an app
 pub async fn destroy_app(context: &AppContext, cmd: &DestroyCommand) -> anyhow::Result<()> {
     let ui = context.ui();
-    ui.new_status_line(format!("Destroying app {}...", &cmd.app_name.yellow()));
+    ui.new_status_line(format!("Destroying app {}...", cmd.app_name.yellow()));
     ui.run(async || {
         // Connect WebSocket before starting the task
         let ws_connection =
             crate::websocket::AuthenticatedWebSocket::connect(context.server()).await;
 
-        let result = get(context.server(), &format!("apps/destroy/{}", &cmd.app_name)).await?;
+        let result = get(context.server(), &format!("apps/destroy/{}", cmd.app_name)).await?;
         let app_context: RunningAppContext =
             serde_json::from_value(result).context("Failed to parse context from API")?;
         crate::api::wait_for_task(context.server(), &app_context, ui, ws_connection).await?;
         ui.success(format!(
             "App {} destroyed successfully",
-            &cmd.app_name.yellow()
+            cmd.app_name.yellow()
         ));
 
-        Ok(format!("App {} destroyed", &cmd.app_name))
+        Ok(format!("App {} destroyed", cmd.app_name))
     })
     .await
 }

--- a/scottyctl/src/commands/apps/list.rs
+++ b/scottyctl/src/commands/apps/list.rs
@@ -50,16 +50,13 @@ pub async fn list_apps(context: &AppContext) -> anyhow::Result<()> {
 /// Get info for a specific app
 pub async fn info_app(context: &AppContext, cmd: &InfoCommand) -> anyhow::Result<()> {
     let ui = context.ui();
-    ui.new_status_line(format!(
-        "Getting info for app {}...",
-        &cmd.app_name.yellow()
-    ));
+    ui.new_status_line(format!("Getting info for app {}...", cmd.app_name.yellow()));
     ui.run(async || {
         let result = get(context.server(), &format!("apps/info/{}", cmd.app_name)).await?;
         let app_data: AppData = serde_json::from_value(result)?;
         ui.success(format!(
             "Info for app {} received successfully",
-            &cmd.app_name.yellow()
+            cmd.app_name.yellow()
         ));
         format_app_info(&app_data)
     })

--- a/scottyctl/src/commands/apps/management.rs
+++ b/scottyctl/src/commands/apps/management.rs
@@ -26,7 +26,7 @@ use super::{format_app_info, get_app_info};
 /// Create a new app
 pub async fn create_app(context: &AppContext, cmd: &CreateCommand) -> anyhow::Result<()> {
     let ui = context.ui();
-    ui.new_status_line(format!("Creating app {}...", &cmd.app_name.yellow()));
+    ui.new_status_line(format!("Creating app {}...", cmd.app_name.yellow()));
     ui.run(async || {
         ui.new_status_line("Collecting files...");
         let file_list = collect_files(&cmd.docker_compose_path)?;
@@ -138,21 +138,21 @@ pub async fn create_app(context: &AppContext, cmd: &CreateCommand) -> anyhow::Re
 
         ui.new_status_line(format!(
             "Beaming your app {} up to {} ({})...",
-            &cmd.app_name.yellow(),
-            &context.server().server.yellow(),
+            cmd.app_name.yellow(),
+            context.server().server.yellow(),
             size.blue()
         ));
         let result = get_or_post(context.server(), "apps/create", "POST", Some(payload)).await?;
 
         ui.success(format!(
             "App {} beamed up to {} ({})!",
-            &cmd.app_name.yellow(),
-            &context.server().server.yellow(),
+            cmd.app_name.yellow(),
+            context.server().server.yellow(),
             size.blue()
         ));
         ui.new_status_line(format!(
             "Waiting for app {} to start...",
-            &cmd.app_name.yellow()
+            cmd.app_name.yellow()
         ));
         let app_context: RunningAppContext =
             serde_json::from_value(result).context("Failed to parse context from API")?;
@@ -161,7 +161,7 @@ pub async fn create_app(context: &AppContext, cmd: &CreateCommand) -> anyhow::Re
         let app_data = get_app_info(context.server(), &app_context.app_data.name).await?;
         ui.success(format!(
             "App {} started successfully!",
-            &cmd.app_name.yellow(),
+            cmd.app_name.yellow(),
         ));
 
         format_app_info(&app_data)


### PR DESCRIPTION
Rust 1.97 clippy added the useless_borrows_in_formatting lint, which
fails CI since clippy runs with -D warnings. Applied cargo clippy --fix
plus cargo fmt across the workspace; no behavior changes.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Mb3y4UUNoYFjjs4BNxtxmB