### PR TITLE
refactor(tasks): own task state in a per-task actor

### DIFF
--- a/.ai/kenkeep/ENTRY.md
+++ b/.ai/kenkeep/ENTRY.md
@@ -1,6 +1,6 @@
 ---
 schema_version: 3
-nodes_hash: 'sha256:2232d57165271e8cc365380cd4f71d266bbf0187bd4ca1cc489034ac80761a79'
+nodes_hash: 'sha256:754d76b36a1600268ce752761f9ff1cc5c92f0ddb3a1ddbea1c97cb0f6d16200'
 node_count: 83
 ---
 # kenkeep

--- a/.ai/kenkeep/GRAPH.md
+++ b/.ai/kenkeep/GRAPH.md
@@ -1,6 +1,6 @@
 ---
 schema_version: 3
-nodes_hash: 'sha256:2232d57165271e8cc365380cd4f71d266bbf0187bd4ca1cc489034ac80761a79'
+nodes_hash: 'sha256:754d76b36a1600268ce752761f9ff1cc5c92f0ddb3a1ddbea1c97cb0f6d16200'
 node_count: 83
 ---
 # kenkeep Graph
@@ -305,7 +305,7 @@ Total nodes: 83
 ## map-state-machine-errors-bubble-to-task-failure
 
 - **kind:** map
-- **title:** State machine handler errors always mark the task Failed
+- **title:** Task state is owned by a per-task actor; errors and panics always mark it Failed
 - **path:** apps/lifecycle/map-state-machine-errors-bubble-to-task-failure.md
 - **tags:** state-machine, tasks, docker
 

--- a/.ai/kenkeep/nodes/apps/lifecycle/index.md
+++ b/.ai/kenkeep/nodes/apps/lifecycle/index.md
@@ -17,7 +17,7 @@ _None._
 ## Components (what exists)
 - Open [**App-create file content is a base64 string on the wire**](map-app-create-file-content-is-a-base64-string-on-the-wire.md) to learn about: File.content serializes as a base64 string; deserialization also accepts a legacy JSON int array and strips the extra base64 layer. #api #app-create #serialization #file-upload
 - Open [**Apps are categorized as owned, supported, or unsupported**](map-app-types-owned-supported-unsupported.md) to learn about: Scotty validates compose.yml and sorts apps into owned/supported/unsupported, each with different lifecycle guarantees. #scotty #apps #vocabulary
-- Open [**State machine handler errors always mark the task Failed**](map-state-machine-errors-bubble-to-task-failure.md) to learn about: App lifecycle state machines propagate handler errors (and panics) up through spawn() so the owning task is always marked Failed instead of hanging forever. #state-machine #tasks #docker
+- Open [**Task state is owned by a per-task actor; errors and panics always mark it Failed**](map-state-machine-errors-bubble-to-task-failure.md) to learn about: One actor per task owns TaskDetails; the state machine Context holds the only TaskHandle, so a dropped, errored or panicked operation is always marked Failed and the terminal transition happens exactly once. #state-machine #tasks #docker
 
 ## By topic
 
@@ -64,11 +64,11 @@ _None._
 ### #serialization
 - Open [**App-create file content is a base64 string on the wire**](map-app-create-file-content-is-a-base64-string-on-the-wire.md) — File.content serializes as a base64 string; deserialization also accepts a legacy JSON int array and strips the extra base64 layer.
 ### #state-machine
-- Open [**State machine handler errors always mark the task Failed**](map-state-machine-errors-bubble-to-task-failure.md) — App lifecycle state machines propagate handler errors (and panics) up through spawn() so the owning task is always marked Failed instead of hanging forever.
+- Open [**Task state is owned by a per-task actor; errors and panics always mark it Failed**](map-state-machine-errors-bubble-to-task-failure.md) — One actor per task owns TaskDetails; the state machine Context holds the only TaskHandle, so a dropped, errored or panicked operation is always marked Failed and the terminal transition happens exactly once.
 ### #status
 - Open [**Running status treats clean one-shot exits as completed, gates URLs per-service**](practice-container-status-one-shot-completion.md) — App status aggregation distinguishes a clean Exited(0) one-shot container from a crash, and the frontend shows a service's URL based on that service's own status rather than the aggregate app status.
 ### #tasks
-- Open [**State machine handler errors always mark the task Failed**](map-state-machine-errors-bubble-to-task-failure.md) — App lifecycle state machines propagate handler errors (and panics) up through spawn() so the owning task is always marked Failed instead of hanging forever.
+- Open [**Task state is owned by a per-task actor; errors and panics always mark it Failed**](map-state-machine-errors-bubble-to-task-failure.md) — One actor per task owns TaskDetails; the state machine Context holds the only TaskHandle, so a dropped, errored or panicked operation is always marked Failed and the terminal transition happens exactly once.
 ### #vocabulary
 - Open [**An app is any folder in the apps directory containing compose.yml**](../anatomy/map-app-anatomy.md) — Apps are identified by folder name; service hostnames derive from app name + service name unless overridden.
 - Open [**Apps are categorized as owned, supported, or unsupported**](map-app-types-owned-supported-unsupported.md) — Scotty validates compose.yml and sorts apps into owned/supported/unsupported, each with different lifecycle guarantees.

--- a/.ai/kenkeep/nodes/apps/lifecycle/map-state-machine-errors-bubble-to-task-failure.md
+++ b/.ai/kenkeep/nodes/apps/lifecycle/map-state-machine-errors-bubble-to-task-failure.md
@@ -1,9 +1,10 @@
 ---
 type: map
-title: State machine handler errors always mark the task Failed
+title: Task state is owned by a per-task actor; errors and panics always mark it Failed
 description: >-
-  App lifecycle state machines propagate handler errors (and panics) up through
-  spawn() so the owning task is always marked Failed instead of hanging forever.
+  One actor per task owns TaskDetails; the state machine Context holds the only
+  TaskHandle, so a dropped, errored or panicked operation is always marked Failed
+  and the terminal transition happens exactly once.
 tags:
   - state-machine
   - tasks
@@ -13,8 +14,15 @@ kk_id: map-state-machine-errors-bubble-to-task-failure
 kk_derived_from: []
 kk_relates_to: []
 kk_depends_on: []
-kk_confidence: medium
+kk_confidence: high
 ---
-The state machine runner's `spawn()` returns a joinable result that propagates handler errors instead of only logging them internally. Callers (including nested state machines used by create/destroy app flows) route through a single shared completion helper (`Context::complete_task()`) so a task is always marked Failed on handler error or panic, and the WebSocket completion broadcast always fires exactly once.
+Each task is owned by one actor (`scotty/src/tasks/actor.rs`): the actor holds the `TaskDetails`, folds `TaskEvent`s from a bounded mailbox, and publishes immutable `Arc<TaskDetails>` snapshots on a `watch` channel. `TaskManager` only stores snapshot receivers. Writers use a cloneable `TaskWriter` (output lines, step started, subprocess exited); the single non-clonable `TaskHandle` lives in the state machine `Context` and is the only thing that can terminate the task.
 
-Any new state-machine handler or nested state machine must let errors propagate through this path rather than swallowing them, otherwise the owning task can be left running indefinitely with no terminal state reported to clients.
+Guarantees that follow from ownership rather than discipline:
+- `Terminate` is applied once; later terminations are logged and ignored, so the completion broadcast and status line happen exactly once.
+- Dropping the `TaskHandle` without terminating (panic, swallowed error, forgotten completion handler) fails the task with "aborted unexpectedly", so nothing can stay `Running` forever. `run_sm` therefore drops the machine's JoinHandle.
+- A subprocess exit (`run_task_and_wait`) only records the exit code; it never changes the task state. Only `TaskCompletionHandler` terminates, after refreshing app data (a failed refresh fails the task with `FailureKind::RefreshFailed`; a missing compose file after destroy is not a failure).
+- Nested machines (`rebuild_app_prepare`/`purge_app_prepare` with `nested: true`) have no completion handler and no error state; they share the parent's context and let errors propagate via `helper::join_outcome`.
+- Output streaming follows the snapshot `watch` and ends only when the snapshot is terminal and every line was sent, so the final status line is never lost.
+
+New handlers write via `ctx.task.writer()` and must not terminate; if a new top-level operation is added it ends with `TaskCompletionHandler::success`/`failure`.

--- a/.beans/scotty-676o--own-task-state-in-a-per-task-actor-task-actor.md
+++ b/.beans/scotty-676o--own-task-state-in-a-per-task-actor-task-actor.md
@@ -1,0 +1,21 @@
+---
+# scotty-676o
+title: Own task state in a per-task actor (task-actor)
+status: completed
+type: task
+priority: normal
+created_at: 2026-09-04T23:29:47Z
+updated_at: 2026-09-04T23:43:56Z
+---
+
+Implement OpenSpec change task-actor: per-task actor owns TaskDetails, TaskHandle/TaskWriter, registry, state machine wiring, output streaming via watch. Refs #894.
+
+## Summary of Changes
+
+- New `scotty/src/tasks/actor.rs`: per-task actor (mailbox + watch snapshots), `TaskWriter`, `TaskHandle` (Drop fails an unterminated task), `Outcome`/`FailureKind`.
+- `TaskManager` is a registry of snapshot receivers; `start_process` reports output and exit code only and returns a JoinHandle; cleanup is TTL on terminal snapshots.
+- `Context` owns the `TaskHandle`; `run_sm` drops the machine handle; `TaskCompletionHandler` terminates once (refresh failure -> Failed, missing compose file -> ok); `run_task_and_wait` awaits the subprocess and never changes task state.
+- Nested rebuild/purge machines (`nested: true`) have no completion handler.
+- Output streaming follows the watch channel and ends after the terminal snapshot.
+- scottyctl fails on `state == Failed` regardless of exit code.
+- Ported Docker regression test for #894; unit tests for actor, manager, run_sm, completion handler, streaming.

--- a/openspec/changes/linear-operations/.openspec.yaml
+++ b/openspec/changes/linear-operations/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-09-05
+skip_specs: true

--- a/openspec/changes/linear-operations/design.md
+++ b/openspec/changes/linear-operations/design.md
@@ -1,0 +1,76 @@
+## Context
+
+See proposal.md for motivation. After `task-actor`, the state machine `Context` owns the `TaskHandle`; `run_sm` spawns the machine and drops its `JoinHandle`, and `TaskCompletionHandler` is the only place that terminates the task. Seven operations are built by `*_prepare` functions that register `StateHandler` structs under state enum variants. Create and destroy nest rebuild and purge via a `nested: bool` flag that suppresses the inner machine's completion handler and error state. Handlers receive `Arc<RwLock<Context>>` but never write to it.
+
+Constraints: the public functions `create_app`, `destroy_app`, `rebuild_app`, `purge_app`, `run_app`, `stop_app`, `force_stop_app`, `run_app_custom_action` keep their signatures (they return `RunningAppContext` immediately); status lines, notifications and task states must stay byte-identical so the frontend, scottyctl and the Docker regression test are unaffected.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Every operation is one `async fn` readable top to bottom; `?` is the only error edge.
+- Exactly one place terminates a task and sends the notification.
+- Nesting is a function call.
+- Delete `state_machine.rs` and the handler indirection without changing observable behavior.
+
+**Non-Goals:**
+- Changing which steps an operation runs, their order, timeouts or messages.
+- Making steps resumable, persistent or observable as states.
+- Touching the actor, `TaskManager` or the read path.
+
+## Decisions
+
+### D1: `async fn` per operation, step functions instead of handler structs
+
+Each `*_prepare` becomes `async fn <op>_steps(ctx: &Context, ...) -> anyhow::Result<()>`; each handler struct becomes `pub async fn <step>(ctx: &Context, <former fields>) -> anyhow::Result<()>` in `docker/steps/`. The `next_state` fields disappear because sequencing is the function body.
+
+Alternatives: keep `StateMachine` with a builder to reduce ceremony (still spreads control flow over a map); a generic `Vec<Box<dyn Step>>` pipeline (loses per-step argument types and gains nothing over sequential `await`s). Rust's `async fn` already compiles to a state machine, so a hand-written one on top only duplicates it.
+
+### D2: One `run_operation` wrapper replaces `run_sm` and `TaskCompletionHandler`
+
+```rust
+pub async fn run_operation<F>(
+    app_state: SharedAppState,
+    app: &AppData,
+    notification: Option<Message>,
+    op: impl FnOnce(Arc<Context>) -> F + Send + 'static,
+) -> anyhow::Result<RunningAppContext>
+where F: Future<Output = anyhow::Result<()>> + Send
+```
+
+It creates the `Context` (which creates the task), writes the "Starting app" status line, returns the `RunningAppContext`, and spawns:
+
+1. `let result = op(ctx.clone()).await;`
+2. `let refresh = refresh_app_data(&ctx).await;` (skipped when the compose file no longer exists, as today)
+3. `ctx.task.terminate(outcome(result, refresh))` where a refresh error wins over success (`FailureKind::RefreshFailed`), a step error is `StepFailed`, otherwise `Finished`.
+4. Send `notification` only on `Finished`.
+
+The `TaskHandle::Drop` fallback still covers a panic inside `op`. The `Context` is shared as `Arc<Context>` (no `RwLock`), because nothing mutates it.
+
+Alternative: keep `TaskCompletionHandler` as a function called at the end of each operation. Rejected: it would have to be called in every error path of every operation, which is exactly the class of bug `task-actor` closed.
+
+### D3: Nested operations are plain calls
+
+`create_steps` calls `rebuild_steps(ctx, recreate_lb = false).await?`; `destroy_steps` calls `purge_steps(ctx, PurgeAppMethod::Down).await?`. Because `*_steps` never terminate the task or notify (only `run_operation` does), the `nested` flag and `join_outcome` are unnecessary. `rebuild_app` is then `run_operation(app_state, app, Some(AppRebuilt), |ctx| rebuild_steps(ctx, true))`.
+
+### D4: Step failures name the step
+
+`run_operation` wraps each operation's error with the failing step via `anyhow::Context` in the step functions (`.context("docker compose up")`), and the terminal status line becomes `Operation failed for app '<name>': <error chain>`. Today the line carries no cause because `StateMachine::run` swallows the error before `TaskCompletionHandler` runs. This is the one deliberate message change; scottyctl and the frontend do not parse it, and the Docker test only asserts the success line.
+
+### D5: Tracing per step
+
+`StateMachine::run` logged every transition. Each step function is annotated with `#[instrument(skip(ctx), fields(app = %ctx.app_data.name))]`, which yields the same information as spans, plus timing.
+
+### D6: Module layout
+
+`docker/state_machine_handlers/` is renamed to `docker/steps/`; `context.rs` moves with it. `run_task_and_wait` stays as the shared subprocess step. `helper.rs` keeps `wait_for_containers_ready` and gains `run_operation`.
+
+## Risks / Trade-offs
+
+- [A step is accidentally left out or reordered during the port] → Port one operation per commit; for each, diff the ordered list of status lines from the old machine (captured by the Docker test for create/destroy and by `docker compose` unit tests for the others) against the new function.
+- [Behavior difference in the failure status line (D4)] → Intentional; documented here and in the kenkeep node. Consumers only branch on `state`.
+- [`run_operation` closure type gymnastics obscure the code] → Keep the signature simple (`FnOnce(Arc<Context>) -> impl Future`), one call site per operation; if the bound becomes noisy, box the future.
+- [Loss of the generic `StateMachine` for future non-linear flows] → None exist today; if one appears, an `async fn` with a `loop`/`match` still expresses it.
+
+## Migration Plan
+
+Single PR after `task-actor` lands, one commit per operation plus a final deletion commit, so a regression can be bisected to one operation. No deployment or data migration; rollback is reverting the PR.

--- a/openspec/changes/linear-operations/proposal.md
+++ b/openspec/changes/linear-operations/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+With task ownership moved into the per-task actor (`task-actor`), the `StateMachine` no longer carries any guarantee: its states are never persisted, inspected or resumed, every machine is a straight line with one error edge, and its indirection (state enum + handler struct + `add_handler` per step, `Arc<RwLock<Context>>`, the `nested` flag for create/destroy, an error handler whose own error is swallowed) is now the main source of accidental complexity in the app lifecycle code. An operation should read top to bottom as one async function where `?` is the error edge.
+
+## What Changes
+
+- Replace the seven `*_prepare` state machines (create, destroy, rebuild, purge, run, stop, custom action) with one plain `async fn` each that calls step functions in sequence.
+- Replace `run_sm` and `TaskCompletionHandler` with one `run_operation` wrapper that spawns the operation, refreshes app data, terminates the task exactly once and sends the notification.
+- Turn each `StateHandler` struct in `docker/state_machine_handlers/` into a step function `async fn step(ctx: &Context, ...) -> anyhow::Result<()>`.
+- Nested operations become plain calls (`create` awaits `rebuild_steps`, `destroy` awaits `purge_steps`); the `nested: bool` parameters and `join_outcome` are removed.
+- `Context` is passed as `&Context` (it is never mutated); `Arc<RwLock<Context>>` disappears.
+- Delete `scotty/src/state_machine.rs`, the seven state enums and the handler structs.
+- Log each step in an `info_span!` so the "Running handler for state X" trace is replaced by an equivalent span.
+
+No user-visible behavior changes: task states, status lines, notifications, REST and WebSocket payloads stay the same.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+None. This is a pure refactor; the requirements in `task-lifecycle` (from the `task-actor` change) are preserved, and `.openspec.yaml` sets `skip_specs: true`.
+
+## Impact
+
+- `scotty/src/docker/{create_app,destroy_app,rebuild_app,purge_app,run_app,stop_app,run_app_custom_action}.rs`: rewritten as linear functions.
+- `scotty/src/docker/state_machine_handlers/*`: handler structs become step functions (module renamed to `docker/steps/`).
+- `scotty/src/docker/helper.rs`: `run_sm` and `join_outcome` replaced by `run_operation`.
+- `scotty/src/state_machine.rs`: deleted, including its tests.
+- Public API of the `docker` module (`create_app`, `destroy_app`, ... returning `RunningAppContext`) is unchanged, so REST handlers are untouched.
+- Tests: unit tests in `helper.rs` and `task_completion_handler.rs` are re-targeted at `run_operation`; the Docker regression test `test_scoped_create_visibility` stays as the end-to-end check.
+- kenkeep node `map-state-machine-errors-bubble-to-task-failure` and the `apps/lifecycle` index need an update.

--- a/openspec/changes/linear-operations/tasks.md
+++ b/openspec/changes/linear-operations/tasks.md
@@ -1,0 +1,31 @@
+## 1. Foundation
+
+- [ ] 1.1 Add `run_operation` to `scotty/src/docker/helper.rs` per design D2 (creates `Context` as `Arc<Context>`, starting status line, spawn, refresh, single `terminate`, notification on success); verify unit tests: success ends `Finished` with the success line, a step error ends `Failed` with the error text in the status line, a refresh failure ends `Failed` and suppresses the notification, a panicking closure ends `Failed` with "aborted unexpectedly"
+- [ ] 1.2 Rename `docker/state_machine_handlers/` to `docker/steps/`, move `context.rs`, drop `RwLock` from `Context` usage; verify `cargo build -p scotty` compiles with the old machines still calling into it (temporary `Arc<RwLock<Context>>` shims allowed only inside this task)
+
+## 2. Step functions
+
+- [ ] 2.1 Convert `CreateDirectoryHandler`, `RemoveDirectoryHandler`, `SaveSettingsHandler`, `SaveFilesHandler`, `UpdateAppDataHandler` into `async fn` steps taking `&Context` plus their former fields; verify `cargo test -p scotty` passes
+- [ ] 2.2 Convert `RunDockerLoginHandler`, `RunDockerComposeHandler`, `WaitForAllContainersHandler`, `EnsureAppNetworkHandler`, `TeardownAppNetworkHandler` into steps; each wraps its error with `.context("<step name>")`; verify existing network handler unit tests pass against the new functions
+- [ ] 2.3 Convert `CreateLoadBalancerConfig` and `RunPostActionsHandler` into steps; verify their existing unit tests pass
+
+## 3. Operations (one commit each)
+
+- [ ] 3.1 `stop_app` and `force_stop_app` via `run_operation` + `stop_steps`; verify unit test asserts the ordered status lines end with "Completed: ..." and the `AppStopped` notification is passed
+- [ ] 3.2 `purge_app` via `purge_steps(ctx, method)`; verify unit test for both `PurgeAppMethod` variants builds the expected compose command
+- [ ] 3.3 `run_app` via `run_steps`; verify unit test on step order (login, network, up, wait, post actions, update)
+- [ ] 3.4 `run_app_custom_action` via `custom_action_steps`; verify existing `validate_action_exists` tests still pass and the `AppCustomActionCompleted` notification carries the action
+- [ ] 3.5 `rebuild_app` via `rebuild_steps(ctx, recreate_load_balancer_config)`; verify the `recreate` branch only runs when `app.settings.is_some() && recreate` (unit test)
+- [ ] 3.6 `create_app` via `create_steps` calling `rebuild_steps(ctx, false)`; remove `RunDockerComposeBuildHandler`; verify `cargo test --no-default-features --test test_scoped_create_visibility -- --ignored` passes with exactly one completion line
+- [ ] 3.7 `destroy_app` via `destroy_steps` calling `purge_steps(ctx, Down)`; remove `RunDockerComposeDownHandler`; verify the same Docker test's destroy phase ends `Finished`
+
+## 4. Removal
+
+- [ ] 4.1 Delete `scotty/src/state_machine.rs`, `task_completion_handler.rs`, `run_sm`, `join_outcome`, the seven state enums and the `nested` parameters; verify `rg -n "StateMachine|StateHandler|nested" scotty/src` returns nothing and `cargo clippy --workspace --all-targets -- -D warnings` is clean
+- [ ] 4.2 Move the `failed_refresh_still_terminates_task` and `missing_compose_file_completes_successfully` tests onto `run_operation`; verify `cargo test -p scotty --lib docker::helper` passes
+
+## 5. Wrap-up
+
+- [ ] 5.1 `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --no-default-features`, Docker regression test; verify all green
+- [ ] 5.2 Update kenkeep node `map-state-machine-errors-bubble-to-task-failure` (rename to describe `run_operation` + linear steps, drop state machine wording) and the `apps/lifecycle` index; run `npx kenkeep index rebuild`; verify no stale-node warning
+- [ ] 5.3 Create a bean, complete it with a summary, and commit the series with `jj` as `refactor(docker): replace lifecycle state machines with linear operations`; verify `jj log` shows one commit per operation plus foundation and removal commits

--- a/openspec/changes/task-actor/.openspec.yaml
+++ b/openspec/changes/task-actor/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-05

--- a/openspec/changes/task-actor/design.md
+++ b/openspec/changes/task-actor/design.md
@@ -1,0 +1,73 @@
+## Context
+
+See proposal.md - Why. Today `TaskDetails` is an `Arc<RwLock<_>>` aliased by `TaskManager.processes` (scotty/src/tasks/manager.rs), `Context.task` (state_machine_handlers/context.rs), every handler, and the WebSocket output streamer (tasks/output_streaming.rs), which polls `get_task_output` and infers the end of a stream from `output_collection_active`. `start_process_with_settings` registers each subprocess under the task's own uuid, so the map entry for an operation is overwritten by every step and `last_exit_code` is a per-process fact stored on a per-operation record. `run_task_and_wait` polls the subprocess JoinHandle every 100 ms and rebroadcasts `TaskInfoUpdated`. Create nests the rebuild state machine and destroy nests purge on the same `Context`.
+
+This slice keeps `StateMachine` and the seven lifecycle machines. It replaces who owns the task and how readers observe it.
+
+## Goals / Non-Goals
+
+**Goals:**
+- One owner per task; terminal-once by construction, not by comment or latch.
+- Readers subscribe; no polling of a lock, no ordering hazard between last line and terminal state.
+- Hand-rolled actor (Ryhl, "Actors with Tokio") so the mechanics are visible: owned struct, mpsc mailbox, watch for snapshots, handle for producers.
+- Wire compatibility: `TaskDetails`, `TaskOutputData`, `TaskInfoUpdated`, `TaskOutputStreamStarted/Ended` unchanged.
+
+**Non-Goals:**
+- Replacing `StateMachine` with linear async functions (later slice).
+- Durability across server restart.
+- A supervision tree or an actor library (`ractor`, `kameo`); revisit once the shape is proven.
+
+## Decisions
+
+**D1. Actor per task, spawned on task creation.**
+```rust
+enum TaskEvent {
+    StepStarted { step: String },
+    Output(OutputStreamType, String),
+    SubprocessExited { exit_code: Option<i32> },
+    Terminate(Outcome),
+}
+enum Outcome { Finished { status: String }, Failed { kind: FailureKind, status: String } }
+enum FailureKind { StepFailed, RefreshFailed, Aborted }
+struct TaskActor { details: TaskDetails, snapshot: watch::Sender<Arc<TaskDetails>>, mailbox: mpsc::Receiver<TaskEvent> }
+```
+The actor loop folds each event into `details`, then `snapshot.send_replace(Arc::new(details.clone()))`. `Terminate` is applied once: a second `Terminate` is logged and dropped. When the mailbox closes with the task still `Running`, the actor applies `Terminate { Failed, "aborted unexpectedly" }` itself. That is Erlang monitor semantics without a supervisor: the producers' handles are the link.
+Alternative considered: keep the lock, add a latch (PR #897). Rejected: the latch is a runtime check of an invariant the type system can carry.
+
+**D2. Two producer types.**
+- `TaskWriter: Clone` sends `StepStarted`, `Output`, `SubprocessExited`. Handlers and the subprocess pump get this.
+- `TaskHandle` (not `Clone`) wraps a `TaskWriter` plus the right to send `Terminate`. `impl Drop for TaskHandle`: if `terminate` was never called, send `Terminate { Failed, "aborted unexpectedly (internal error)" }`. Panics and cancellation unwind through `Drop`, so `run_sm` needs no supervisor task and `helper.rs` loses `join_outcome`.
+`Context` holds the `TaskHandle` behind the existing `Arc<RwLock<Context>>`; `TaskCompletionHandler` calls `handle.terminate(...)`. Because `Terminate` is idempotent in the actor, the success handler failing and routing to the failure handler is harmless.
+Alternative: make `terminate(self)` consume the handle. Rejected for this slice: `Context` is shared through `Arc<RwLock>` by the state machine framework, so consuming is not expressible until the control flow is rewritten.
+
+**D3. Nested machines borrow, they do not own.** `create_app` and `destroy_app` spawn the nested machine over the same `Context` and therefore the same `TaskHandle`. Nested machines are built without a completion handler and without an error state (`nested: true`, as in PR #897); their errors propagate to the awaiting parent handler. Only the outer machine terminates and notifies. The actor rejects a second `Terminate` regardless, so a mistake here degrades to a log line, not a wrong state.
+
+**D4. Subprocesses are steps, not tasks.** `TaskManager::start_process` takes a `TaskWriter`, spawns the child, pumps stdout/stderr as `Output` events, and returns `JoinHandle<anyhow::Result<i32>>`. A spawn error is returned (no `expect`) and also emitted as an `Output` line. `run_task_and_wait` awaits the handle instead of polling and fails the step when the exit code is not zero or is missing. `SubprocessExited` updates `last_exit_code` only. `TaskInfoUpdated` is broadcast by the actor on each snapshot rather than by the handler loop.
+
+**D5. Readers use snapshots.** `TaskManager` becomes `HashMap<Uuid, TaskEntry { snapshot: watch::Receiver<Arc<TaskDetails>>, writer: TaskWriter }>`. `get_task_details` is `borrow().clone()`, lock-free. `output_streaming` subscribes with `watch::Receiver::changed()`, sends lines with sequence greater than the last sent, and ends the stream when the snapshot is terminal and all lines are sent. Since a terminal snapshot is produced after the final `Output` event was folded, the stream cannot end early. `output_collection_active` stays in `TaskDetails` for the wire but is derived (`state == Running`).
+Alternative: `broadcast` channel for lines. Rejected: lagging receivers lose lines; `watch` plus sequence numbers gives at-least-once without a second buffer.
+
+**D6. Metric and finish time move into the actor** (`Terminate` fold). `record_task_finished` fires once per task.
+
+**D7. Failure reason is structured internally, prose on the wire.** `Terminate` carries an `Outcome` whose failure variant names a closed `FailureKind`; the actor renders the status line from it. `TaskDetails` keeps only `state` plus the status line, so nothing on the wire changes and no client has to branch on prose. When a consumer needs the kind (retry policy, a metric label, a frontend badge), adding `reason: Option<FailureKind>` to `TaskDetails` with `#[serde(default)]` is one field, and the data already exists at every failure site. Prior art: Kubernetes `Condition.reason` (program) next to `message` (human); Erlang exit reasons are terms, not strings. Alternative: string only. Rejected because reconstructing the kind from prose later is guesswork, and the enum costs about ten lines now.
+
+**D8. Cleanup.** `run_cleanup_task` removes entries whose snapshot is terminal and older than the TTL; dropping the entry drops the last `watch::Receiver`, which is fine because the actor exits when its mailbox closes.
+
+## Risks / Trade-offs
+
+- [Mailbox backpressure on chatty subprocesses] → bounded mpsc (e.g. 1024); the output pump `await`s `send`, which slows the reader of the child pipe, which applies OS backpressure to the child. Acceptable; log if the queue stays full.
+- [Snapshot cloning cost per event with large outputs] → snapshots are `Arc<TaskDetails>`; the actor clones `details` once per event. Batch `Output` events through the existing `TimedBuffer` in the pump (10 lines or 100 ms) so a build log produces tens, not thousands, of snapshots per second.
+- [`Drop` on `TaskHandle` runs inside a panicking unwind] → the send is `try_send` on an unbounded-enough mailbox and never panics; if the mailbox is full the actor's close-detection path fails the task anyway.
+- [Frontend relies on `output_collection_active`] → keep the field, derive it; no frontend change.
+- [Nested flag still exists] → accepted for this slice; disappears when control flow becomes linear.
+
+## Migration Plan
+
+Each step compiles and ships alone:
+1. Add `tasks/actor.rs` with `TaskActor`, `TaskEvent`, `TaskWriter`, `TaskHandle`, snapshot type, unit tests. Nothing uses it yet.
+2. `TaskManager` spawns an actor per task and stores `TaskEntry`; `get_task_details`/`get_task_list`/`add_task_*` route through it. Readers unchanged in behavior.
+3. `Context` carries `TaskHandle`; `TaskCompletionHandler` terminates through it; `run_sm` stops dropping the JoinHandle. Delete `complete_task`'s lock dance.
+4. Subprocess identity: `start_process` takes a `TaskWriter`, returns a JoinHandle of the exit code; `run_task_and_wait` awaits.
+5. `output_streaming` and the WebSocket handler subscribe to the `watch`.
+6. Nested mode for rebuild/purge; scottyctl trusts `state`; Docker regression test for create and destroy.
+Rollback at any step is a revert of that step.

--- a/openspec/changes/task-actor/proposal.md
+++ b/openspec/changes/task-actor/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+App-operation tasks are tracked in an `Arc<RwLock<TaskDetails>>` that is written from several places: the task manager after every subprocess, the completion handler, and every reader that pokes at it. Because no single component owns the task, the task manager marked a task `Finished` after the first `docker compose` subprocess exited (issue #894, a scoped token got 403 on `apps/info` because Casbin scopes were not yet synced), and the attempt to fix that in PR #897 uncovered eight further latent defects, each a consequence of shared, multi-writer state. This change gives every task exactly one owner.
+
+## What Changes
+
+- Introduce a per-task actor that owns `TaskDetails` by value. Producers send events (step started, output line, subprocess exited, terminal) over a channel; the actor folds them into the task and publishes snapshots on a `watch` channel.
+- Introduce a non-clonable `TaskHandle` that is the only way to emit the terminal event. Dropping it without a terminal event (panic, cancellation, swallowed error) fails the task. Nested state machines borrow the handle instead of sharing the task.
+- Subprocesses get their own identity; a subprocess exit updates `last_exit_code` and emits a step event but never changes the task state.
+- REST, WebSocket and output streaming read from the actor's snapshot and subscribe to its `watch` instead of polling a lock. Terminal state and the final status line are published in one snapshot.
+- The state machine framework and the seven lifecycle machines keep driving the steps. Control flow is out of scope for this slice.
+- Carried over from PR #897 as design-independent: scottyctl trusts task `state` over `last_exit_code`; a subprocess that cannot be spawned records the error and fails the step; the Docker-backed create-and-destroy regression test.
+- **BREAKING (internal only)**: `TaskManager::start_process` and the `add_task_*` helpers change signature. The wire format of `TaskDetails` and all WebSocket task messages is unchanged.
+
+## Capabilities
+
+### New Capabilities
+- `task-lifecycle`: guarantees of app-operation tasks: every task reaches exactly one terminal state, only the operation owner sets it, subprocesses never terminate a task, and observers never see a terminal task with truncated output.
+
+### Modified Capabilities
+
+## Impact
+
+- `scotty/src/tasks/`: new `actor.rs` (actor, events, handle, snapshot), `manager.rs` becomes a registry of actors, `output_streaming.rs` subscribes instead of polling.
+- `scotty/src/docker/helper.rs`, `state_machine_handlers/context.rs`, `task_completion_handler.rs`, `run_task_and_wait.rs`: use `TaskHandle`.
+- `scotty/src/api/rest/handlers/tasks.rs`, `scotty/src/api/websocket/handlers/tasks.rs`: read snapshots.
+- `scottyctl/src/api.rs`: failure decided by `state`.
+- Metrics: `record_task_finished` fires once per task, inside the actor.
+- No change to `scotty-types::TaskDetails`, `WebSocketMessage`, or the frontend.

--- a/openspec/changes/task-actor/specs/task-lifecycle/spec.md
+++ b/openspec/changes/task-actor/specs/task-lifecycle/spec.md
@@ -1,0 +1,67 @@
+## Purpose
+
+Defines the lifecycle guarantees of app-operation tasks: every task started for an app operation reaches a terminal state exactly once, that state is set only by the operation owner, and observers see a consistent view of state and output.
+
+## ADDED Requirements
+
+### Requirement: Every task reaches a terminal state
+
+The system SHALL move every app-operation task from `Running` to exactly one terminal state, `Finished` or `Failed`, regardless of how the underlying operation ends. A task MUST NOT remain `Running` after the operation has stopped executing.
+
+#### Scenario: Operation completes normally
+- **WHEN** all steps of an app operation succeed
+- **THEN** the task is `Finished` with a finish time set
+
+#### Scenario: A step reports an error
+- **WHEN** a step of an app operation fails with an error
+- **THEN** the task is `Failed` with a finish time set and a status message describing the failure
+
+#### Scenario: A step panics
+- **WHEN** a step of an app operation panics before the operation's completion step has run
+- **THEN** the task is `Failed` with a finish time set and a status message stating that the operation aborted unexpectedly
+- **AND** the panic is logged with the app name and task id
+
+#### Scenario: The failure handling itself fails
+- **WHEN** the operation's own failure-handling step returns an error before it could terminate the task
+- **THEN** the task is still `Failed` with a finish time set
+
+### Requirement: Terminal state is set once and only by the operation owner
+
+Intermediate steps of an operation, such as individual subprocesses, SHALL NOT change the task state. Only the operation owner SHALL set the terminal state, and once set it SHALL NOT be overwritten.
+
+#### Scenario: Subprocess exits during a multi-step operation
+- **WHEN** one subprocess of a multi-step operation exits, successfully or not
+- **THEN** the task remains `Running` and records that subprocess's exit code
+- **AND** the operation decides from the exit code whether to continue or fail
+
+#### Scenario: Subprocess cannot be started
+- **WHEN** a subprocess cannot be spawned or waited on
+- **THEN** the reason is recorded in the task output
+- **AND** the operation treats the step as failed
+
+#### Scenario: A second terminal event arrives
+- **WHEN** the owner attempts to terminate a task that is already terminal
+- **THEN** the task state, finish time and output are left unchanged
+- **AND** the attempt is logged
+
+#### Scenario: Nested operation
+- **WHEN** an operation runs another operation as one of its steps (create runs rebuild, destroy runs purge)
+- **THEN** only the outer operation terminates the task and sends its notification
+- **AND** a failure in the inner operation fails the outer operation
+
+### Requirement: Observers see a consistent task view
+
+Any snapshot of a task exposed over the REST API or WebSocket SHALL be internally consistent: a terminal snapshot SHALL contain the final status line, and output lines SHALL be delivered in the order they were produced. A subscriber SHALL learn about a change in task state or output without polling.
+
+#### Scenario: Poller reads a terminal task
+- **WHEN** a client reads a task whose state is `Finished` or `Failed`
+- **THEN** the returned output already contains the completion status line
+
+#### Scenario: Output stream ends
+- **WHEN** a client streams a task's output and the task terminates
+- **THEN** the client receives every remaining output line before the stream-ended message
+
+#### Scenario: Client waits for completion
+- **WHEN** scottyctl waits for a task
+- **THEN** it reports failure whenever the task state is `Failed`, regardless of the last subprocess exit code
+- **AND** it shows a subprocess exit code only when that exit code is non-zero

--- a/openspec/changes/task-actor/tasks.md
+++ b/openspec/changes/task-actor/tasks.md
@@ -1,0 +1,37 @@
+## 1. Actor core
+
+- [x] 1.1 Create `scotty/src/tasks/actor.rs` with `TaskEvent`, `Outcome`/`FailureKind`, `TaskActor` (owns `TaskDetails`, folds events, publishes `watch<Arc<TaskDetails>>`), `TaskWriter` (Clone), `TaskHandle` (not Clone, `terminate`, `Drop` fails an unterminated task); verify unit tests: terminal-once (second `Terminate` ignored), drop-without-terminate yields `Failed` with "aborted unexpectedly", output line order preserved, terminal snapshot contains the final status line
+- [x] 1.2 Move finish time and `record_task_finished` into the `Terminate` fold; verify a unit test asserts the metric recorder is called once for two `Terminate` events
+
+## 2. Registry
+
+- [x] 2.1 Change `TaskManager` to spawn one actor per task and store the snapshot receiver per task (no writer: holding one would keep the actor alive after its owner is gone); `get_task_details`, `get_task_list` read snapshots, the `add_task_*` helpers are gone and callers use `TaskWriter`; verify `cargo test -p scotty` passes and REST `GET task/{id}` returns the same JSON shape (existing `secure_response_test`)
+- [x] 2.2 Rewrite `run_cleanup_task` to remove terminal entries older than the TTL; verify a unit test with a short TTL removes a terminated task and keeps a running one
+
+## 3. Ownership in the state machines
+
+- [x] 3.1 `Context` holds a `TaskHandle`; `Context::complete_task` is removed, callers call `task.terminate(Outcome)` (the status line is part of the terminate fold); verify existing state machine unit tests pass
+- [x] 3.2 `run_sm` creates the actor, moves the `TaskHandle` into `Context`, and drops the machine's JoinHandle (the `TaskHandle` in the context fails the task on panic, so no supervisor is needed); verify a unit test with a panicking handler ends `Failed`, and one where the error-state handler itself fails ends `Failed`
+- [x] 3.3 `TaskCompletionHandler` terminates through the handle; a failed app-data refresh fails the task and propagates; a missing compose file (destroy) skips the refresh; verify unit tests `failed_refresh_still_terminates_task` and `missing_compose_file_completes_successfully` (ported from PR #897)
+
+## 4. Subprocesses as steps
+
+- [x] 4.1 `TaskManager::start_process` takes a `TaskWriter`, returns `JoinHandle<anyhow::Result<i32>>`, emits `StepStarted`/`Output`/`SubprocessExited`, returns spawn errors instead of panicking and records them as output; verify unit tests: `true` leaves the task `Running` with exit code 0, `false` records exit code 1, an unknown command records the error text and `None`
+- [x] 4.2 `run_task_and_wait` awaits the JoinHandle, fails the step on non-zero or missing exit code, and stops broadcasting `TaskInfoUpdated` itself (the actor broadcasts on `StepStarted`/`SubprocessExited`/`Terminate`; covered by the Docker regression test, no dedicated messenger unit test)
+
+## 5. Read path
+
+- [x] 5.1 `output_streaming` subscribes to the task's `watch`, sends lines by sequence number, ends the stream only when the snapshot is terminal and all lines were sent; verify a unit test that terminates a task with 3 pending lines delivers all 3 before `TaskOutputStreamEnded`
+- [x] 5.2 WebSocket and REST task handlers read snapshots; `output_collection_active` is derived from `state`; verify `cargo test -p scotty` and `cd frontend && bun run check` pass unchanged
+
+## 6. Nesting, client, regression test
+
+- [x] 6.1 `rebuild_app_prepare` and `purge_app_prepare` take `nested: bool` (no completion handler, no error state); create and destroy pass `true`; verified by the Docker regression test (create ends with exactly one completion line); `StateMachine` handlers are private so no direct unit test
+- [x] 6.2 scottyctl: both wait loops fail on `state == Failed` regardless of exit code and show the exit code only when non-zero; verify `cargo test -p scottyctl`
+- [x] 6.3 Port `scotty/tests/test_scoped_create_visibility.rs` from PR #897 (create with scoped token, `apps/info` 200, exactly one completion line, destroy ends `Finished`); verify `cargo test --no-default-features --test test_scoped_create_visibility -- --ignored` passes with Docker
+
+## 7. Wrap-up
+
+- [x] 7.1 `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, Docker test; verify all green
+- [x] 7.2 Update the kenkeep node `map-state-machine-errors-bubble-to-task-failure` to describe the actor ownership; verify `npx kenkeep index rebuild` reports no stale nodes
+- [x] 7.3 Create a bean, complete it with a summary, and commit with `jj` as `refactor(tasks): own task state in a per-task actor` referencing #894; verify `jj log` shows one commit on top of main

--- a/scotty-core/src/tasks/task_details.rs
+++ b/scotty-core/src/tasks/task_details.rs
@@ -1,12 +1,1 @@
-use std::sync::Arc;
-use tokio::sync::RwLock;
-
-// Import the types from scotty-types (which now has embedded TaskOutput)
 pub use scotty_types::{State, TaskDetails, TaskOutput};
-
-/// TaskState with embedded output via TaskDetails
-#[derive(Debug, Clone)]
-pub struct TaskState {
-    pub handle: Option<Arc<RwLock<tokio::task::JoinHandle<()>>>>,
-    pub details: Arc<RwLock<TaskDetails>>,
-}

--- a/scotty/src/docker/create_app.rs
+++ b/scotty/src/docker/create_app.rs
@@ -16,7 +16,7 @@ use scotty_core::notification_types::{Message, MessageType};
 use scotty_core::settings::app_blueprint::ActionName;
 use scotty_core::tasks::running_app_context::RunningAppContext;
 
-use super::helper::run_sm;
+use super::helper::{join_outcome, run_sm};
 use super::rebuild_app::rebuild_app_prepare;
 use super::state_machine_handlers::context::Context;
 use super::state_machine_handlers::create_directory_handler::CreateDirectoryHandler;
@@ -41,14 +41,11 @@ impl StateHandler<CreateAppStates, Context> for RunDockerComposeBuildHandler<Cre
         context: Arc<RwLock<Context>>,
     ) -> anyhow::Result<CreateAppStates> {
         let app_state = &context.read().await.app_state;
-        let sm = rebuild_app_prepare(app_state, &self.app, false).await?;
+        let sm = rebuild_app_prepare(app_state, &self.app, false, true).await?;
         let handle = sm.spawn(context.clone());
 
-        // Gracefully handle both errors and panics from nested state machine
-        handle
-            .await
-            .map_err(|e| anyhow::anyhow!("Docker compose rebuild task panicked: {}", e))?
-            .context("Docker compose rebuild failed")?;
+        // Errors and panics of the nested machine fail this handler.
+        join_outcome(handle.await).context("Docker compose rebuild failed")?;
 
         Ok(self.next_state)
     }

--- a/scotty/src/docker/destroy_app.rs
+++ b/scotty/src/docker/destroy_app.rs
@@ -13,7 +13,7 @@ use scotty_core::notification_types::Message;
 use scotty_core::notification_types::MessageType;
 use scotty_core::tasks::running_app_context::RunningAppContext;
 
-use super::helper::run_sm;
+use super::helper::{join_outcome, run_sm};
 use super::purge_app::purge_app_prepare;
 use super::purge_app::PurgeAppMethod;
 use super::state_machine_handlers::context::Context;
@@ -37,14 +37,11 @@ impl StateHandler<DestroyAppStates, Context> for RunDockerComposeDownHandler<Des
         // TeardownAppNetworkHandler. That is why destroy has no explicit network
         // teardown state of its own: the per-app proxy network is removed here,
         // via the nested purge state machine.
-        let sm = purge_app_prepare(&self.app, PurgeAppMethod::Down).await?;
+        let sm = purge_app_prepare(&self.app, PurgeAppMethod::Down, true).await?;
         let handle = sm.spawn(context.clone());
 
-        // Gracefully handle both errors and panics from nested state machine
-        handle
-            .await
-            .map_err(|e| anyhow::anyhow!("Docker compose down task panicked: {}", e))?
-            .context("Docker compose down failed")?;
+        // Errors and panics of the nested machine fail this handler.
+        join_outcome(handle.await).context("Docker compose down failed")?;
 
         Ok(self.next_state)
     }

--- a/scotty/src/docker/docker_compose.rs
+++ b/scotty/src/docker/docker_compose.rs
@@ -1,35 +1,23 @@
-use std::{path::Path, sync::Arc};
+use std::path::Path;
 
-use scotty_core::{tasks::task_details::TaskDetails, utils::secret::SecretHashMap};
-use tokio::sync::RwLock;
+use scotty_core::utils::secret::SecretHashMap;
 use tracing::instrument;
 
-use crate::{app_state::SharedAppState, onepassword::lookup::resolve_environment_variables};
+use crate::{
+    app_state::SharedAppState, onepassword::lookup::resolve_environment_variables,
+    tasks::actor::TaskWriter,
+};
 
-/// Runs a docker-compose command asynchronously as a task
-///
-/// # Arguments
-///
-/// * `shared_app` - The shared application state
-/// * `docker_compose_path` - Path to the docker-compose file
-/// * `command` - The main command to run
-/// * `args` - Additional arguments for the command
-/// * `env` - Environment variables (SecretHashMap) to pass to the command
-/// * `task` - Task details for tracking
-///
-/// # Returns
-///
-/// Task details after execution
+/// Runs a docker-compose command as a step of the task behind `writer`.
+/// Resolves to the process exit code; the task state is left to its owner.
 pub async fn run_task(
     shared_app: &SharedAppState,
     docker_compose_path: &Path,
     command: &str,
     args: &[&str],
     env: &SecretHashMap,
-    task: Arc<RwLock<TaskDetails>>,
-) -> anyhow::Result<TaskDetails> {
-    let manager = shared_app.task_manager.clone();
-
+    writer: TaskWriter,
+) -> anyhow::Result<tokio::task::JoinHandle<anyhow::Result<i32>>> {
     // Resolve environment variables (1Password, substitutions, etc.)
     let resolved_environment = resolve_environment_variables(&shared_app.settings, env).await;
 
@@ -37,16 +25,10 @@ pub async fn run_task(
         .parent()
         .ok_or_else(|| anyhow::anyhow!("Docker compose path has no parent directory"))?;
 
-    // Expose secrets for process execution
     let exposed_env = resolved_environment.expose_all();
-    let task_id = manager
-        .start_process(parent_dir, command, args, &exposed_env, task.clone())
-        .await;
-
-    manager
-        .get_task_details(&task_id)
-        .await
-        .ok_or_else(|| anyhow::anyhow!("Task not found"))
+    Ok(shared_app
+        .task_manager
+        .start_process(parent_dir, command, args, &exposed_env, writer))
 }
 
 /// Runs a docker-compose command synchronously and returns the output

--- a/scotty/src/docker/helper.rs
+++ b/scotty/src/docker/helper.rs
@@ -23,33 +23,31 @@ where
         + std::marker::Send
         + std::fmt::Debug,
 {
-    let context = Context::create(app_state, app);
-    {
-        let context = context.write().await;
-        let task = context.task.clone();
-        let task_id = task.read().await.id;
-        context
-            .app_state
-            .task_manager
-            .add_task(&task_id, task.clone(), None)
+    let context = Context::create(app_state, app).await;
+    let running = {
+        let ctx = context.read().await;
+        ctx.task
+            .writer()
+            .status(format!("Starting app '{}'", app.name))
             .await;
+        ctx.as_running_app_context()
+    };
+    // The join handle is not needed: the context owns the task handle, so a
+    // panicking or erroring machine that never reaches its completion handler
+    // fails the task when the context is dropped.
+    let _handle = sm.spawn(context);
+    Ok(running)
+}
 
-        // Add initial status message for the app operation
-        context
-            .app_state
-            .task_manager
-            .add_task_status(&task_id, format!("Starting app '{}'", app.name))
-            .await;
+/// Flatten the result of awaiting a spawned state machine.
+pub fn join_outcome(
+    joined: Result<anyhow::Result<()>, tokio::task::JoinError>,
+) -> anyhow::Result<()> {
+    match joined {
+        Ok(result) => result,
+        Err(join) if join.is_panic() => Err(anyhow!("aborted unexpectedly (internal error)")),
+        Err(join) => Err(anyhow!("was cancelled: {join}")),
     }
-    // TODO(scotty-f1dd): State machine handle is intentionally dropped here to allow immediate
-    // API response. This means we cannot detect panics in the state machine task.
-    // Errors are handled via TaskCompletionHandler, but panics are silently lost.
-    // Future refactoring should support multiple handles in TaskState to track both
-    // the state machine handle and any subprocess handles it spawns.
-    let _handle = sm.spawn(context.clone());
-
-    // Return immediately with the context, task is running in background
-    Ok(context.clone().read().await.as_running_app_context().await)
 }
 
 /// Wait for all containers to reach a non-starting state.
@@ -151,5 +149,118 @@ pub async fn wait_for_containers_ready(
     match result {
         Ok(r) => r,
         Err(_) => Err(anyhow!("Timeout waiting for containers to be ready")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state_machine::StateHandler;
+    use crate::tasks::actor::{FailureKind, Outcome};
+    use scotty_core::tasks::task_details::{State, TaskDetails};
+    use std::sync::Arc;
+    use std::time::Duration;
+    use tokio::sync::RwLock;
+
+    #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+    enum S {
+        Start,
+        Fail,
+        Done,
+    }
+
+    enum Behaviour {
+        Panic,
+        Error,
+        TerminateThenError,
+    }
+
+    struct H(Behaviour);
+
+    #[async_trait::async_trait]
+    impl StateHandler<S, Context> for H {
+        async fn transition(&self, _from: &S, context: Arc<RwLock<Context>>) -> anyhow::Result<S> {
+            match self.0 {
+                Behaviour::Panic => panic!("boom"),
+                Behaviour::Error => anyhow::bail!("step failed"),
+                Behaviour::TerminateThenError => {
+                    context
+                        .read()
+                        .await
+                        .task
+                        .terminate(Outcome::failed(FailureKind::StepFailed, "handler said so"))
+                        .await;
+                    anyhow::bail!("after completion")
+                }
+            }
+        }
+    }
+
+    async fn run(start: Behaviour, on_error: Behaviour) -> TaskDetails {
+        let app_state = crate::api::test_utils::create_test_app_state_with_config(
+            "tests/test_bearer_auth",
+            None,
+        )
+        .await;
+        let mut sm = StateMachine::new(S::Start, S::Done);
+        sm.set_error_state(S::Fail);
+        sm.add_handler(S::Start, Arc::new(H(start)));
+        sm.add_handler(S::Fail, Arc::new(H(on_error)));
+        let app = AppData {
+            name: "supervised".into(),
+            ..Default::default()
+        };
+        let ctx = run_sm(app_state.clone(), &app, sm).await.unwrap();
+        assert_eq!(ctx.task.state, State::Running);
+
+        let mut rx = app_state
+            .task_manager
+            .subscribe(&ctx.task.id)
+            .await
+            .unwrap();
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let task = rx.borrow_and_update().clone();
+                if task.state != State::Running {
+                    return (*task).clone();
+                }
+                rx.changed().await.unwrap();
+            }
+        })
+        .await
+        .expect("task never left Running")
+    }
+
+    #[tokio::test]
+    async fn panicking_handler_fails_task() {
+        let task = run(Behaviour::Panic, Behaviour::Error).await;
+        assert_eq!(task.state, State::Failed);
+        assert!(task.finish_time.is_some());
+        assert!(task
+            .output
+            .lines
+            .iter()
+            .any(|l| l.content.contains("aborted unexpectedly")));
+    }
+
+    #[tokio::test]
+    async fn failing_error_handler_still_fails_task() {
+        let task = run(Behaviour::Error, Behaviour::Error).await;
+        assert_eq!(task.state, State::Failed);
+        assert!(task.finish_time.is_some());
+    }
+
+    #[tokio::test]
+    async fn drop_does_not_overwrite_terminal_state() {
+        let task = run(Behaviour::Error, Behaviour::TerminateThenError).await;
+        assert_eq!(task.state, State::Failed);
+        let statuses: Vec<_> = task
+            .output
+            .lines
+            .iter()
+            .filter(|l| l.content.contains("handler said so") || l.content.contains("aborted"))
+            .collect();
+        assert_eq!(statuses.len(), 1, "{statuses:?}");
+        assert!(statuses[0].content.contains("handler said so"));
     }
 }

--- a/scotty/src/docker/purge_app.rs
+++ b/scotty/src/docker/purge_app.rs
@@ -34,15 +34,20 @@ pub enum PurgeAppMethod {
     Down,
     Rm,
 }
+/// Build the purge state machine. See `rebuild_app_prepare` for `nested`:
+/// when run inside destroy, this machine must not complete the shared task.
 #[instrument]
 pub async fn purge_app_prepare(
     app: &AppData,
     purge_method: PurgeAppMethod,
+    nested: bool,
 ) -> anyhow::Result<StateMachine<PurgeAppStates, Context>> {
     info!("Purging app {} at {}", app.name, &app.docker_compose_path);
 
     let mut sm = StateMachine::new(PurgeAppStates::RunDockerCompose, PurgeAppStates::Done);
-    sm.set_error_state(PurgeAppStates::SetFailed);
+    if !nested {
+        sm.set_error_state(PurgeAppStates::SetFailed);
+    }
 
     let command = match purge_method {
         PurgeAppMethod::Down => vec!["down", "-v", "--rmi", "all"],
@@ -66,20 +71,26 @@ pub async fn purge_app_prepare(
     sm.add_handler(
         PurgeAppStates::UpdateAppData,
         Arc::new(UpdateAppDataHandler::<PurgeAppStates> {
-            next_state: PurgeAppStates::SetFinished,
+            next_state: if nested {
+                PurgeAppStates::Done
+            } else {
+                PurgeAppStates::SetFinished
+            },
         }),
     );
-    sm.add_handler(
-        PurgeAppStates::SetFinished,
-        Arc::new(TaskCompletionHandler::success(
-            PurgeAppStates::Done,
-            Some(Message::new(MessageType::AppPurged, app)),
-        )),
-    );
-    sm.add_handler(
-        PurgeAppStates::SetFailed,
-        Arc::new(TaskCompletionHandler::failure(PurgeAppStates::Done, None)),
-    );
+    if !nested {
+        sm.add_handler(
+            PurgeAppStates::SetFinished,
+            Arc::new(TaskCompletionHandler::success(
+                PurgeAppStates::Done,
+                Some(Message::new(MessageType::AppPurged, app)),
+            )),
+        );
+        sm.add_handler(
+            PurgeAppStates::SetFailed,
+            Arc::new(TaskCompletionHandler::failure(PurgeAppStates::Done, None)),
+        );
+    }
     Ok(sm)
 }
 
@@ -91,6 +102,6 @@ pub async fn purge_app(
     if app.status == AppStatus::Unsupported {
         return Err(AppError::OperationNotSupportedForLegacyApp(app.name.clone()).into());
     }
-    let sm = purge_app_prepare(app, PurgeAppMethod::Rm).await?;
+    let sm = purge_app_prepare(app, PurgeAppMethod::Rm, false).await?;
     run_sm(app_state, app, sm).await
 }

--- a/scotty/src/docker/rebuild_app.rs
+++ b/scotty/src/docker/rebuild_app.rs
@@ -40,11 +40,18 @@ pub enum RebuildAppStates {
     Done,
 }
 
+/// Build the rebuild state machine.
+///
+/// `nested` means the machine runs inside another operation (create) that
+/// shares the same task: it then neither terminates the task nor sends a
+/// notification, and errors propagate to the parent instead of being routed
+/// to its own failure state. Only the outermost operation completes a task.
 #[instrument]
 pub async fn rebuild_app_prepare(
     app_state: &SharedAppState,
     app: &AppData,
     recreate_load_balancer_config: bool,
+    nested: bool,
 ) -> anyhow::Result<StateMachine<RebuildAppStates, Context>> {
     info!(
         "Rebuilding app {} at {}",
@@ -60,7 +67,9 @@ pub async fn rebuild_app_prepare(
         },
         RebuildAppStates::Done,
     );
-    sm.set_error_state(RebuildAppStates::SetFailed);
+    if !nested {
+        sm.set_error_state(RebuildAppStates::SetFailed);
+    }
 
     if start_with_recreate {
         sm.add_handler(
@@ -139,20 +148,26 @@ pub async fn rebuild_app_prepare(
     sm.add_handler(
         RebuildAppStates::UpdateAppData,
         Arc::new(UpdateAppDataHandler::<RebuildAppStates> {
-            next_state: RebuildAppStates::SetFinished,
+            next_state: if nested {
+                RebuildAppStates::Done
+            } else {
+                RebuildAppStates::SetFinished
+            },
         }),
     );
-    sm.add_handler(
-        RebuildAppStates::SetFinished,
-        Arc::new(TaskCompletionHandler::success(
-            RebuildAppStates::Done,
-            Some(Message::new(MessageType::AppRebuilt, app)),
-        )),
-    );
-    sm.add_handler(
-        RebuildAppStates::SetFailed,
-        Arc::new(TaskCompletionHandler::failure(RebuildAppStates::Done, None)),
-    );
+    if !nested {
+        sm.add_handler(
+            RebuildAppStates::SetFinished,
+            Arc::new(TaskCompletionHandler::success(
+                RebuildAppStates::Done,
+                Some(Message::new(MessageType::AppRebuilt, app)),
+            )),
+        );
+        sm.add_handler(
+            RebuildAppStates::SetFailed,
+            Arc::new(TaskCompletionHandler::failure(RebuildAppStates::Done, None)),
+        );
+    }
     Ok(sm)
 }
 
@@ -164,6 +179,6 @@ pub async fn rebuild_app(
     if app.status == AppStatus::Unsupported {
         return Err(AppError::OperationNotSupportedForLegacyApp(app.name.clone()).into());
     }
-    let sm = rebuild_app_prepare(&app_state, app, true).await?;
+    let sm = rebuild_app_prepare(&app_state, app, true, false).await?;
     run_sm(app_state, app, sm).await
 }

--- a/scotty/src/docker/state_machine_handlers/context.rs
+++ b/scotty/src/docker/state_machine_handlers/context.rs
@@ -2,94 +2,50 @@ use std::sync::Arc;
 
 use scotty_core::{
     apps::app_data::AppData,
-    tasks::{
-        running_app_context::RunningAppContext,
-        task_details::{State, TaskDetails},
-    },
-    websocket::message::WebSocketMessage,
+    tasks::{running_app_context::RunningAppContext, task_details::TaskDetails},
 };
-use tokio::sync::RwLock;
+use tokio::sync::{watch, RwLock};
 
-use crate::app_state::SharedAppState;
+use crate::{
+    app_state::SharedAppState,
+    tasks::actor::{Snapshot, TaskHandle},
+};
 
+/// Shared by every handler of one operation, including nested state machines.
+/// The context owns the task: when the last reference goes away (normal end,
+/// error, or panic) without `task.terminate`, the task is failed automatically.
 pub struct Context {
     pub app_state: SharedAppState,
-    pub task: Arc<RwLock<TaskDetails>>,
+    pub task: TaskHandle,
+    task_snapshot: watch::Receiver<Snapshot>,
     pub app_data: AppData,
 }
 
 impl Context {
-    pub async fn as_running_app_context(&self) -> RunningAppContext {
-        RunningAppContext {
-            task: self.task.read().await.clone(),
-            app_data: self.app_data.clone(),
-        }
-    }
-
-    pub fn create(app_state: SharedAppState, app_data: &AppData) -> Arc<RwLock<Self>> {
-        Arc::new(RwLock::new(Context {
-            app_state: app_state.clone(),
-            app_data: app_data.clone(),
-            task: Arc::new(RwLock::new(TaskDetails {
+    pub async fn create(app_state: SharedAppState, app_data: &AppData) -> Arc<RwLock<Self>> {
+        let (task, task_snapshot) = app_state
+            .task_manager
+            .create_task(TaskDetails {
                 app_name: Some(app_data.name.clone()),
                 ..TaskDetails::default()
-            })),
+            })
+            .await;
+        Arc::new(RwLock::new(Context {
+            app_state,
+            task,
+            task_snapshot,
+            app_data: app_data.clone(),
         }))
     }
 
-    /// Complete a task with the given state (Finished or Failed)
-    ///
-    /// This is the single source of truth for task completion logic.
-    /// It handles:
-    /// - Updating task state, finish_time, and output_collection_active
-    /// - Broadcasting the task update via WebSocket
-    /// - Adding status messages to task output
-    ///
-    /// Used by both TaskCompletionHandler and helper.rs to ensure consistent behavior.
-    ///
-    /// # Arguments
-    /// * `target_state` - State::Finished or State::Failed
-    /// * `status_message` - Message to add to task output
-    /// * `is_error` - Whether to use add_task_status_error (true) or add_task_status (false)
-    pub async fn complete_task(&self, target_state: State, status_message: String, is_error: bool) {
-        // Get task ID first
-        let task_id = self.task.read().await.id;
+    pub fn task_snapshot(&self) -> Snapshot {
+        self.task_snapshot.borrow().clone()
+    }
 
-        // Add status message BEFORE marking output collection as inactive
-        // This ensures the message is available for the WebSocket stream to send
-        if is_error {
-            self.app_state
-                .task_manager
-                .add_task_status_error(&task_id, status_message)
-                .await;
-        } else {
-            self.app_state
-                .task_manager
-                .add_task_status(&task_id, status_message)
-                .await;
+    pub fn as_running_app_context(&self) -> RunningAppContext {
+        RunningAppContext {
+            task: (*self.task_snapshot()).clone(),
+            app_data: self.app_data.clone(),
         }
-
-        // Small yield to ensure the status message write completes and is visible
-        // to the WebSocket stream's next poll (which happens every 100ms)
-        tokio::task::yield_now().await;
-
-        // Now update task state and mark output collection as complete
-        let updated_task_details = {
-            let mut task_details = self.task.write().await;
-
-            // Update state
-            task_details.state = target_state;
-            task_details.output_collection_active = false;
-            task_details.finish_time = Some(chrono::Utc::now());
-
-            // Clone for broadcast (released write lock before broadcast)
-            task_details.clone()
-        };
-
-        // Broadcast task update via WebSocket
-        self.app_state
-            .messenger
-            .broadcast_to_all(WebSocketMessage::TaskInfoUpdated(updated_task_details))
-            .await;
     }
 }

--- a/scotty/src/docker/state_machine_handlers/run_task_and_wait.rs
+++ b/scotty/src/docker/state_machine_handlers/run_task_and_wait.rs
@@ -1,12 +1,15 @@
 use std::path::Path;
 
 use scotty_core::utils::secret::SecretHashMap;
-use tracing::{debug, error, info};
+use tracing::{error, info};
 
 use crate::docker::docker_compose::run_task;
 
 use super::context::Context;
 
+/// Run a subprocess as one step of the current task and wait for it.
+/// A non-zero exit, a signal, or a spawn failure is an error for the caller;
+/// the task itself stays `Running` until its owner terminates it.
 pub async fn run_task_and_wait(
     context: &Context,
     docker_compose_path: &Path,
@@ -21,108 +24,41 @@ pub async fn run_task_and_wait(
         args = ?args,
         "Starting task: {}", msg
     );
+    let writer = context.task.writer();
 
-    let task_id = context.task.read().await.id;
-
-    let task_details = run_task(
+    let handle = run_task(
         &context.app_state,
         docker_compose_path,
         command,
         args,
         env,
-        context.task.clone(),
+        writer.clone(),
     )
     .await?;
-    context
-        .app_state
-        .messenger
-        .broadcast_to_all(
-            scotty_core::websocket::message::WebSocketMessage::TaskInfoUpdated(
-                task_details.clone(),
-            ),
-        )
-        .await;
 
-    let handle = context
-        .app_state
-        .task_manager
-        .get_task_handle(&task_details.id)
-        .await
-        .ok_or_else(|| anyhow::anyhow!("Task not found"))?;
+    let failure = match handle.await {
+        Ok(Ok(0)) => None,
+        Ok(Ok(code)) => Some(format!("{msg} (exit code {code})")),
+        Ok(Err(e)) => Some(format!("{msg}: {e:#}")),
+        Err(join) => Some(format!("{msg}: process task {join}")),
+    };
 
-    debug!("Waiting for {} to finish", msg);
-    while !handle.read().await.is_finished() {
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-        let task = context
-            .app_state
-            .task_manager
-            .get_task_details(&task_details.id)
-            .await
-            .ok_or_else(|| anyhow::anyhow!("Task not found"))?;
-
-        context
-            .app_state
-            .messenger
-            .broadcast_to_all(
-                scotty_core::websocket::message::WebSocketMessage::TaskInfoUpdated(task.clone()),
-            )
-            .await;
+    if let Some(reason) = failure {
+        writer.status_error(format!("Failed: {reason}")).await;
+        error!(
+            app_name = %context.app_data.name,
+            command = %command,
+            args = ?args,
+            "Task failed: {}", reason
+        );
+        return Err(anyhow::anyhow!("{reason}"));
     }
 
-    let task = context
-        .app_state
-        .task_manager
-        .get_task_details(&task_details.id)
-        .await
-        .ok_or_else(|| anyhow::anyhow!("Task not found"))?;
-
-    // Add completion status based on exit code
-    if let Some(last_exit_code) = task.last_exit_code {
-        if last_exit_code != 0 {
-            context
-                .app_state
-                .task_manager
-                .add_task_status_error(
-                    &task_id,
-                    format!("Failed: {} (exit code {})", msg, last_exit_code),
-                )
-                .await;
-
-            error!(
-                app_name = %context.app_data.name,
-                command = %command,
-                args = ?args,
-                exit_code = last_exit_code,
-                "Task failed: {}", msg
-            );
-
-            return Err(anyhow::anyhow!(
-                "{} failed with exit code {}",
-                msg,
-                last_exit_code
-            ));
-        }
-    }
-
-    context
-        .app_state
-        .task_manager
-        .add_task_status(&task_id, format!("Completed: {}", msg))
-        .await;
-
+    writer.status(format!("Completed: {}", msg)).await;
     info!(
         app_name = %context.app_data.name,
         command = %command,
         "Task completed successfully: {}", msg
     );
-
-    context
-        .app_state
-        .messenger
-        .broadcast_to_all(
-            scotty_core::websocket::message::WebSocketMessage::TaskInfoUpdated(task.clone()),
-        )
-        .await;
-
     Ok(())
 }

--- a/scotty/src/docker/state_machine_handlers/task_completion_handler.rs
+++ b/scotty/src/docker/state_machine_handlers/task_completion_handler.rs
@@ -1,10 +1,15 @@
 use std::sync::Arc;
 
-use scotty_core::{notification_types::Message, tasks::task_details::State};
+use anyhow::Context as _;
+use scotty_core::notification_types::Message;
 use tokio::sync::RwLock;
 use tracing::instrument;
 
-use crate::{docker::find_apps::inspect_app, state_machine::StateHandler};
+use crate::{
+    docker::find_apps::inspect_app,
+    state_machine::StateHandler,
+    tasks::actor::{FailureKind, Outcome},
+};
 
 use super::context::Context;
 
@@ -72,27 +77,53 @@ where
 {
     #[instrument(skip(self, _from, context))]
     async fn transition(&self, _from: &S, context: Arc<RwLock<Context>>) -> anyhow::Result<S> {
-        // Determine state and message based on completion type
-        let (target_state, status_msg_prefix, use_error_status) = match self.completion_type {
-            CompletionType::Success => (State::Finished, "Successfully completed", false),
-            CompletionType::Failure => (State::Failed, "Operation failed for", true),
+        let ctx = context.read().await;
+        // Already terminated (e.g. the success handler failed its refresh and
+        // routed here): nothing left to do.
+        if ctx.task.is_terminated() {
+            return Ok(self.next_state.clone());
+        }
+        let app_name = ctx.app_data.name.clone();
+
+        // Refresh app state to get current Docker container info. No compose
+        // file means the app was removed (destroy deletes the directory before
+        // completing): nothing to refresh, not a failure.
+        let docker_compose_path = std::path::PathBuf::from(&ctx.app_data.docker_compose_path);
+        let refresh = if !docker_compose_path.exists() {
+            tracing::debug!(
+                "Compose file {} is gone, skipping app data refresh",
+                docker_compose_path.display()
+            );
+            Ok(())
+        } else {
+            match inspect_app(&ctx.app_state, &docker_compose_path).await {
+                Ok(app_data) => ctx.app_state.apps.update_app(app_data).await.map(|_| ()),
+                Err(e) => Err(e),
+            }
         };
 
-        // Refresh app state to get current Docker container info
-        {
-            let ctx = context.read().await;
-            let docker_compose_path = std::path::PathBuf::from(&ctx.app_data.docker_compose_path);
+        let outcome = match (&refresh, self.completion_type) {
+            (Err(e), _) => Outcome::failed(
+                FailureKind::RefreshFailed,
+                format!(
+                    "Operation for app '{app_name}' ended, but refreshing app data failed: {e:#}"
+                ),
+            ),
+            (Ok(()), CompletionType::Success) => Outcome::finished(format!(
+                "Successfully completed operation for app '{app_name}'"
+            )),
+            (Ok(()), CompletionType::Failure) => Outcome::failed(
+                FailureKind::StepFailed,
+                format!("Operation failed for app '{app_name}'"),
+            ),
+        };
+        ctx.task.terminate(outcome).await;
+        drop(ctx);
 
-            let app_data = inspect_app(&ctx.app_state, &docker_compose_path).await?;
-            ctx.app_state.apps.update_app(app_data).await?;
-
-            // Use the shared helper - single source of truth for task completion
-            let app_name = ctx.app_data.name.clone();
-            let status_msg = format!("{} operation for app '{}'", status_msg_prefix, app_name);
-
-            ctx.complete_task(target_state, status_msg, use_error_status)
-                .await;
-        } // Drop ctx read lock here
+        // A failed refresh fails the whole operation: propagate so the state
+        // machine (and any parent awaiting it) sees the error and no success
+        // notification goes out.
+        refresh.context("Refreshing app data after task completion failed")?;
 
         // Send notifications in a dedicated thread (for both success and failure)
         if self.notification.is_some() {
@@ -135,5 +166,93 @@ where
         }
 
         Ok(self.next_state.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use scotty_core::apps::app_data::AppData;
+    use scotty_core::tasks::task_details::State;
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    enum S {
+        Done,
+    }
+
+    async fn completed(app: AppData) -> (anyhow::Result<S>, scotty_types::TaskDetails) {
+        let app_state = crate::api::test_utils::create_test_app_state_with_config(
+            "tests/test_bearer_auth",
+            None,
+        )
+        .await;
+        let context = Context::create(app_state.clone(), &app).await;
+        let result = TaskCompletionHandler::success(S::Done, None)
+            .transition(&S::Done, context.clone())
+            .await;
+
+        let id = context.read().await.task.id();
+        let mut rx = app_state.task_manager.subscribe(&id).await.unwrap();
+        let task = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                let task = rx.borrow_and_update().clone();
+                if task.state != State::Running {
+                    return (*task).clone();
+                }
+                rx.changed().await.unwrap();
+            }
+        })
+        .await
+        .expect("task never terminated");
+        (result, task)
+    }
+
+    /// A compose file outside the apps root cannot be inspected; the task
+    /// must still terminate and the error must propagate.
+    #[tokio::test]
+    async fn failed_refresh_still_terminates_task() {
+        let dir = std::env::temp_dir().join(format!("scotty-refresh-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let compose = dir.join("docker-compose.yml");
+        std::fs::write(&compose, "services: {}\n").unwrap();
+
+        let (result, task) = completed(AppData {
+            name: "unrefreshable".into(),
+            docker_compose_path: compose.to_string_lossy().into_owned(),
+            root_directory: dir.to_string_lossy().into_owned(),
+            ..Default::default()
+        })
+        .await;
+        let _ = std::fs::remove_dir_all(&dir);
+
+        assert!(result.is_err(), "refresh failure must propagate");
+        assert_eq!(task.state, State::Failed);
+        assert!(task.finish_time.is_some());
+        assert!(task
+            .output
+            .lines
+            .iter()
+            .any(|l| l.content.contains("refreshing app data failed")));
+    }
+
+    /// destroy removes the app directory before completing: a missing compose
+    /// file is not a refresh failure.
+    #[tokio::test]
+    async fn missing_compose_file_completes_successfully() {
+        let (result, task) = completed(AppData {
+            name: "destroyed".into(),
+            docker_compose_path: "/nonexistent/scotty-test/docker-compose.yml".into(),
+            root_directory: "/nonexistent/scotty-test".into(),
+            ..Default::default()
+        })
+        .await;
+
+        assert!(result.is_ok());
+        assert_eq!(task.state, State::Finished);
+        assert!(task
+            .output
+            .lines
+            .iter()
+            .any(|l| l.content == "Successfully completed operation for app 'destroyed'"));
     }
 }

--- a/scotty/src/docker/state_machine_handlers/wait_for_all_containers_handler.rs
+++ b/scotty/src/docker/state_machine_handlers/wait_for_all_containers_handler.rs
@@ -2,7 +2,7 @@ use super::context::Context;
 use crate::docker::helper::wait_for_containers_ready;
 use crate::state_machine::StateHandler;
 use anyhow::Context as _;
-use scotty_core::websocket::message::WebSocketMessage;
+use scotty_core::output::OutputStreamType;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::{debug, info, instrument, warn};
@@ -30,12 +30,12 @@ where
 {
     #[instrument(skip(context))]
     async fn transition(&self, _from: &S, context: Arc<RwLock<Context>>) -> anyhow::Result<S> {
-        let (app_state, app_data, task_clone) = {
+        let (app_state, app_data, writer) = {
             let ctx = context.read().await;
             (
                 ctx.app_state.clone(),
                 ctx.app_data.clone(),
-                ctx.task.clone(),
+                ctx.task.writer().clone(),
             )
         };
 
@@ -55,24 +55,14 @@ where
 
         debug!("Found {} containers to wait for", container_ids.len());
 
-        // Add progress message to task output for client visibility
-        let task_id = task_clone.read().await.id;
-        app_state
-            .task_manager
-            .add_task_progress(
-                &task_id,
+        writer
+            .output(
+                OutputStreamType::Progress,
                 format!("Waiting for {} containers to be ready", container_ids.len()),
             )
             .await;
 
         info!("Waiting for containers to be ready: {:?}", container_ids);
-
-        app_state
-            .messenger
-            .broadcast_to_all(WebSocketMessage::TaskInfoUpdated(
-                task_clone.read().await.clone(),
-            ))
-            .await;
 
         // Wait for all containers to reach a non-starting state
         let container_states =
@@ -80,21 +70,10 @@ where
                 .await
                 .context("Failed to wait for containers to be ready")?;
 
-        // Add completion status message to task output for client visibility
-        app_state
-            .task_manager
-            .add_task_status(&task_id, "All containers are ready".to_string())
-            .await;
+        writer.status("All containers are ready").await;
 
         info!("All containers have reached a ready state");
         debug!("Container states: {:?}", container_states);
-
-        app_state
-            .messenger
-            .broadcast_to_all(WebSocketMessage::TaskInfoUpdated(
-                task_clone.read().await.clone(),
-            ))
-            .await;
 
         // Return the next state
         Ok(self.next_state.clone())

--- a/scotty/src/tasks/actor.rs
+++ b/scotty/src/tasks/actor.rs
@@ -1,0 +1,407 @@
+//! One actor per task owns its `TaskDetails`.
+//!
+//! Pattern: Alice Ryhl, "Actors with Tokio". An owned struct runs in its own
+//! tokio task, receives `TaskEvent`s over a bounded mpsc mailbox, folds them
+//! into the details and publishes an immutable snapshot on a `watch` channel.
+//! Nobody else holds a reference to the details, so there is no lock, no
+//! ordering hazard between the last output line and the terminal state, and
+//! the terminal transition happens exactly once by construction.
+//!
+//! Producers come in two flavours:
+//! - [`TaskWriter`] (Clone): output lines, status messages, subprocess exits.
+//! - [`TaskHandle`] (not Clone): the only way to terminate the task. Dropping
+//!   it without terminating fails the task, which is what turns a panic or a
+//!   swallowed error into a visible `Failed` instead of a task stuck `Running`.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use scotty_core::output::OutputStreamType;
+use scotty_core::tasks::task_details::{State, TaskDetails};
+use scotty_core::websocket::message::WebSocketMessage;
+use tokio::sync::mpsc::error::TrySendError;
+use tokio::sync::{mpsc, watch};
+use tracing::{debug, warn};
+use uuid::Uuid;
+
+use crate::api::websocket::WebSocketMessenger;
+use crate::metrics;
+
+/// Immutable view of a task, published after every applied event.
+pub type Snapshot = Arc<TaskDetails>;
+
+const MAILBOX_CAPACITY: usize = 1024;
+
+/// Why a task failed. Kept structured internally so a future consumer can
+/// branch on it; the wire only carries the rendered status line for now.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FailureKind {
+    /// A step returned an error.
+    StepFailed,
+    /// The post-operation app data refresh failed.
+    RefreshFailed,
+    /// The operation ended without terminating its task (panic, dropped handle).
+    Aborted,
+}
+
+#[derive(Debug, Clone)]
+pub enum Outcome {
+    Finished { status: String },
+    Failed { kind: FailureKind, status: String },
+}
+
+impl Outcome {
+    pub fn finished(status: impl Into<String>) -> Self {
+        Self::Finished {
+            status: status.into(),
+        }
+    }
+
+    pub fn failed(kind: FailureKind, status: impl Into<String>) -> Self {
+        Self::Failed {
+            kind,
+            status: status.into(),
+        }
+    }
+
+    fn aborted() -> Self {
+        Self::failed(
+            FailureKind::Aborted,
+            "Operation aborted unexpectedly (internal error)",
+        )
+    }
+}
+
+#[derive(Debug)]
+pub enum TaskEvent {
+    /// A new step (typically a subprocess) started; shown as the task command.
+    StepStarted { command: String },
+    /// Output lines, in order.
+    Output(Vec<(OutputStreamType, String)>),
+    /// A subprocess of this task exited. Never changes the task state.
+    SubprocessExited { exit_code: Option<i32> },
+    /// The operation ended. Applied once; later terminations are ignored.
+    Terminate(Outcome),
+}
+
+/// Spawn the actor for `details`. Returns the owning handle and a snapshot
+/// receiver for readers.
+pub fn spawn(
+    details: TaskDetails,
+    messenger: WebSocketMessenger,
+) -> (TaskHandle, watch::Receiver<Snapshot>) {
+    let id = details.id;
+    let (tx, mailbox) = mpsc::channel(MAILBOX_CAPACITY);
+    let (snapshot, snapshot_rx) = watch::channel(Arc::new(details.clone()));
+    let actor = TaskActor {
+        details,
+        snapshot,
+        mailbox,
+        messenger,
+    };
+    tokio::spawn(actor.run());
+    let handle = TaskHandle {
+        writer: TaskWriter { id, tx },
+        terminated: AtomicBool::new(false),
+    };
+    (handle, snapshot_rx)
+}
+
+struct TaskActor {
+    details: TaskDetails,
+    snapshot: watch::Sender<Snapshot>,
+    mailbox: mpsc::Receiver<TaskEvent>,
+    messenger: WebSocketMessenger,
+}
+
+impl TaskActor {
+    async fn run(mut self) {
+        while let Some(event) = self.mailbox.recv().await {
+            let broadcast = self.apply(event);
+            self.publish(broadcast).await;
+        }
+        // Every writer and the handle are gone. A task that is still Running
+        // at this point can never be terminated by anyone else.
+        if self.details.state == State::Running {
+            warn!(
+                task_id = %self.details.id,
+                "All task producers dropped while Running; failing the task"
+            );
+            self.apply(TaskEvent::Terminate(Outcome::aborted()));
+            self.publish(true).await;
+        }
+        debug!(task_id = %self.details.id, "Task actor stopped");
+    }
+
+    /// Fold one event into the details. Returns whether the change is worth a
+    /// `TaskInfoUpdated` broadcast (output lines are streamed separately).
+    fn apply(&mut self, event: TaskEvent) -> bool {
+        match event {
+            TaskEvent::StepStarted { command } => {
+                self.details.command = command;
+                true
+            }
+            TaskEvent::Output(lines) => {
+                for (stream, line) in lines {
+                    self.details.output.add_line(stream, line);
+                }
+                false
+            }
+            TaskEvent::SubprocessExited { exit_code } => {
+                self.details.last_exit_code = exit_code;
+                true
+            }
+            TaskEvent::Terminate(outcome) => self.terminate(outcome),
+        }
+    }
+
+    fn terminate(&mut self, outcome: Outcome) -> bool {
+        if self.details.state != State::Running {
+            warn!(
+                task_id = %self.details.id,
+                state = ?self.details.state,
+                ?outcome,
+                "Ignoring termination of an already terminal task"
+            );
+            return false;
+        }
+        let (state, stream, status) = match outcome {
+            Outcome::Finished { status } => (State::Finished, OutputStreamType::Status, status),
+            Outcome::Failed { kind, status } => {
+                debug!(task_id = %self.details.id, ?kind, "Task failed");
+                (State::Failed, OutputStreamType::StatusError, status)
+            }
+        };
+        // The status line lands in the same snapshot as the terminal state, so
+        // no reader can observe one without the other.
+        self.details.output.add_line(stream, status);
+        let failed = state == State::Failed;
+        self.details.state = state;
+        self.details.output_collection_active = false;
+        let finish_time = chrono::Utc::now();
+        self.details.finish_time = Some(finish_time);
+
+        let duration_secs = finish_time
+            .signed_duration_since(self.details.start_time)
+            .num_milliseconds() as f64
+            / 1000.0;
+        metrics::metrics().record_task_finished(duration_secs, failed);
+        true
+    }
+
+    async fn publish(&self, broadcast: bool) {
+        let snapshot = Arc::new(self.details.clone());
+        self.snapshot.send_replace(snapshot.clone());
+        if broadcast {
+            self.messenger
+                .broadcast_to_all(WebSocketMessage::TaskInfoUpdated((*snapshot).clone()))
+                .await;
+        }
+    }
+}
+
+/// Cloneable producer of non-terminal events.
+#[derive(Clone, Debug)]
+pub struct TaskWriter {
+    id: Uuid,
+    tx: mpsc::Sender<TaskEvent>,
+}
+
+impl TaskWriter {
+    pub fn id(&self) -> Uuid {
+        self.id
+    }
+
+    async fn send(&self, event: TaskEvent) {
+        if self.tx.send(event).await.is_err() {
+            debug!(task_id = %self.id, "Task actor is gone; dropping event");
+        }
+    }
+
+    pub async fn output(&self, stream: OutputStreamType, line: impl Into<String>) {
+        self.send(TaskEvent::Output(vec![(stream, line.into())]))
+            .await;
+    }
+
+    pub async fn output_lines(&self, lines: Vec<(OutputStreamType, String)>) {
+        if !lines.is_empty() {
+            self.send(TaskEvent::Output(lines)).await;
+        }
+    }
+
+    pub async fn status(&self, message: impl Into<String>) {
+        self.output(OutputStreamType::Status, message).await;
+    }
+
+    pub async fn status_error(&self, message: impl Into<String>) {
+        self.output(OutputStreamType::StatusError, message).await;
+    }
+
+    pub async fn step_started(&self, command: impl Into<String>) {
+        self.send(TaskEvent::StepStarted {
+            command: command.into(),
+        })
+        .await;
+    }
+
+    pub async fn subprocess_exited(&self, exit_code: Option<i32>) {
+        self.send(TaskEvent::SubprocessExited { exit_code }).await;
+    }
+}
+
+/// Owner of a task. Not `Clone`: whoever holds it decides how the task ends.
+#[derive(Debug)]
+pub struct TaskHandle {
+    writer: TaskWriter,
+    terminated: AtomicBool,
+}
+
+impl TaskHandle {
+    pub fn id(&self) -> Uuid {
+        self.writer.id
+    }
+
+    pub fn writer(&self) -> &TaskWriter {
+        &self.writer
+    }
+
+    /// Whether `terminate` has been called on this handle.
+    pub fn is_terminated(&self) -> bool {
+        self.terminated.load(Ordering::Acquire)
+    }
+
+    /// Terminate the task. Returns `false` if it was already terminated
+    /// through this handle; the actor ignores duplicates as well.
+    pub async fn terminate(&self, outcome: Outcome) -> bool {
+        if self.terminated.swap(true, Ordering::AcqRel) {
+            warn!(task_id = %self.id(), ?outcome, "Task already terminated");
+            return false;
+        }
+        self.writer.send(TaskEvent::Terminate(outcome)).await;
+        true
+    }
+}
+
+impl Drop for TaskHandle {
+    fn drop(&mut self) {
+        if self.terminated.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        // Reached on panic unwind or when an operation forgot to terminate.
+        // Cannot await here, so try synchronously and fall back to a spawned
+        // send if the mailbox happens to be full.
+        let tx = self.writer.tx.clone();
+        match tx.try_send(TaskEvent::Terminate(Outcome::aborted())) {
+            Ok(()) | Err(TrySendError::Closed(_)) => {}
+            Err(TrySendError::Full(event)) => {
+                if let Ok(rt) = tokio::runtime::Handle::try_current() {
+                    rt.spawn(async move {
+                        let _ = tx.send(event).await;
+                    });
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::test_utils::create_test_websocket_messenger;
+    use std::time::Duration;
+
+    async fn settled(
+        rx: &mut watch::Receiver<Snapshot>,
+        pred: impl Fn(&TaskDetails) -> bool,
+    ) -> Snapshot {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if pred(&rx.borrow()) {
+                    return rx.borrow().clone();
+                }
+                rx.changed().await.unwrap();
+            }
+        })
+        .await
+        .expect("snapshot never satisfied predicate")
+    }
+
+    fn statuses(task: &TaskDetails) -> Vec<&str> {
+        task.output
+            .lines
+            .iter()
+            .filter(|l| {
+                matches!(
+                    l.stream,
+                    OutputStreamType::Status | OutputStreamType::StatusError
+                )
+            })
+            .map(|l| l.content.as_str())
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn terminal_state_and_status_line_arrive_together() {
+        let (handle, mut rx) = spawn(TaskDetails::default(), create_test_websocket_messenger());
+        handle.writer().status("step one").await;
+        handle.terminate(Outcome::finished("done")).await;
+
+        let task = settled(&mut rx, |t| t.state != State::Running).await;
+        assert_eq!(task.state, State::Finished);
+        assert!(task.finish_time.is_some());
+        assert!(!task.output_collection_active);
+        assert_eq!(statuses(&task), vec!["step one", "done"]);
+    }
+
+    #[tokio::test]
+    async fn second_terminate_is_ignored() {
+        let (handle, mut rx) = spawn(TaskDetails::default(), create_test_websocket_messenger());
+        assert!(
+            handle
+                .terminate(Outcome::failed(FailureKind::StepFailed, "first"))
+                .await
+        );
+        assert!(!handle.terminate(Outcome::finished("second")).await);
+        let first = settled(&mut rx, |t| t.state != State::Running).await;
+
+        // Push another event so a later snapshot exists, then compare.
+        handle.writer().status("late line").await;
+        let later = settled(&mut rx, |t| t.output.lines.len() > first.output.lines.len()).await;
+        assert_eq!(later.state, State::Failed);
+        assert_eq!(later.finish_time, first.finish_time);
+        assert!(!statuses(&later).contains(&"second"));
+    }
+
+    #[tokio::test]
+    async fn dropping_handle_without_terminate_fails_task() {
+        let (handle, mut rx) = spawn(TaskDetails::default(), create_test_websocket_messenger());
+        drop(handle);
+        let task = settled(&mut rx, |t| t.state != State::Running).await;
+        assert_eq!(task.state, State::Failed);
+        assert!(statuses(&task)[0].contains("aborted unexpectedly"));
+    }
+
+    #[tokio::test]
+    async fn output_order_is_preserved_and_subprocess_exit_keeps_running() {
+        let (handle, mut rx) = spawn(TaskDetails::default(), create_test_websocket_messenger());
+        let w = handle.writer().clone();
+        for i in 0..50 {
+            w.output(OutputStreamType::Stdout, format!("line {i}"))
+                .await;
+        }
+        w.subprocess_exited(Some(0)).await;
+        let task = settled(&mut rx, |t| t.last_exit_code == Some(0)).await;
+        assert_eq!(task.state, State::Running);
+        let contents: Vec<_> = task
+            .output
+            .lines
+            .iter()
+            .map(|l| l.content.as_str())
+            .collect();
+        assert_eq!(
+            contents,
+            (0..50).map(|i| format!("line {i}")).collect::<Vec<_>>()
+        );
+        handle.terminate(Outcome::finished("ok")).await;
+    }
+}

--- a/scotty/src/tasks/manager.rs
+++ b/scotty/src/tasks/manager.rs
@@ -1,392 +1,144 @@
-#![allow(dead_code)]
+//! Registry of task actors plus subprocess execution.
+//!
+//! The manager owns nothing but snapshot receivers: each task's state lives in
+//! its actor (see [`crate::tasks::actor`]). Readers get immutable snapshots,
+//! writers go through the `TaskWriter`/`TaskHandle` returned by `create_task`.
 
-use std::path::{Path, PathBuf};
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
 
-use scotty_core::settings::{output::OutputSettings, scheduler_interval::SchedulerInterval};
+use scotty_core::output::OutputStreamType;
+use scotty_core::settings::scheduler_interval::SchedulerInterval;
+use scotty_core::tasks::task_details::{State, TaskDetails};
 use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
-
 use tokio::process::Command;
-use tokio::sync::RwLock;
+use tokio::sync::{watch, RwLock};
 use tracing::{debug, info, instrument};
-
 use uuid::Uuid;
-
-use scotty_core::output::{OutputStreamType, TaskOutput};
-use scotty_core::tasks::task_details::{State, TaskDetails, TaskState};
 
 use crate::api::websocket::WebSocketMessenger;
 use crate::metrics;
+use crate::tasks::actor::{self, Snapshot, TaskHandle, TaskWriter};
 use crate::tasks::timed_buffer::TimedBuffer;
-
-/// Helper function to add multiple lines to task output with a single write lock
-async fn add_output_lines(
-    details: &Arc<RwLock<TaskDetails>>,
-    lines: Vec<(OutputStreamType, String)>,
-    task_id: uuid::Uuid,
-) {
-    if lines.is_empty() {
-        return;
-    }
-
-    let mut details = details.write().await;
-    for (stream_type, line) in lines {
-        details.output.add_line(stream_type, line);
-    }
-    debug!(
-        "Added {} output lines to task {}",
-        details.output.lines.len(),
-        task_id
-    );
-}
-
-/// Helper function to add a single line to task output
-async fn add_output_line(
-    details: &Arc<RwLock<TaskDetails>>,
-    stream_type: OutputStreamType,
-    line: String,
-    task_id: uuid::Uuid,
-) {
-    add_output_lines(details, vec![(stream_type, line)], task_id).await;
-}
-
-/// Helper function to handle task completion consistently
-async fn handle_task_completion(
-    details: &Arc<RwLock<TaskDetails>>,
-    _messenger: &WebSocketMessenger,
-    _task_manager: &TaskManager,
-    task_id: uuid::Uuid,
-    exit_code: Result<i32, anyhow::Error>,
-) {
-    debug!("Handling task completion for task {}", task_id);
-    let (state, status_code, _reason) = match exit_code {
-        Ok(0) => (State::Finished, Some(0), "completed"),
-        Ok(e) => (State::Failed, Some(e), "failed"),
-        Err(_) => (State::Failed, None, "failed"),
-    };
-
-    TaskManager::set_task_finished(details, status_code, state.clone()).await;
-
-    // With the new self-contained streaming approach, no cleanup is needed.
-    // Streams detect task completion and terminate naturally.
-    debug!("Task {} completed with status {:?}", task_id, state);
-}
 
 #[derive(Clone, Debug)]
 pub struct TaskManager {
-    pub processes: Arc<RwLock<HashMap<Uuid, TaskState>>>,
+    tasks: Arc<RwLock<HashMap<Uuid, watch::Receiver<Snapshot>>>>,
     messenger: WebSocketMessenger,
 }
 
 impl TaskManager {
     pub fn new(messenger: WebSocketMessenger) -> Self {
         Self {
-            processes: Arc::new(RwLock::new(HashMap::new())),
+            tasks: Arc::new(RwLock::new(HashMap::new())),
             messenger,
         }
     }
 
-    /// Helper: Get a task's details Arc with minimal lock time
-    async fn get_details_arc(&self, uuid: &Uuid) -> Option<Arc<RwLock<TaskDetails>>> {
-        let processes = self.processes.read().await;
-        processes
-            .get(uuid)
-            .map(|task_state| task_state.details.clone())
+    /// Spawn an actor for `details` and register it. The returned handle owns
+    /// the task: dropping it without `terminate` fails the task.
+    pub async fn create_task(
+        &self,
+        details: TaskDetails,
+    ) -> (TaskHandle, watch::Receiver<Snapshot>) {
+        let id = details.id;
+        let (handle, rx) = actor::spawn(details, self.messenger.clone());
+        let mut tasks = self.tasks.write().await;
+        tasks.insert(id, rx.clone());
+        metrics::metrics().record_task_added(tasks.len());
+        (handle, rx)
     }
 
-    /// Helper: Get all task details Arcs with minimal lock time
-    async fn get_all_details_arcs(&self) -> Vec<Arc<RwLock<TaskDetails>>> {
-        let processes = self.processes.read().await;
-        processes
-            .values()
-            .map(|task_state| task_state.details.clone())
-            .collect()
-    }
-
-    /// Helper: Modify a task's details with minimal lock time
-    async fn modify_task_details<F>(&self, uuid: &Uuid, f: F) -> bool
-    where
-        F: FnOnce(&mut TaskDetails),
-    {
-        let Some(details_arc) = self.get_details_arc(uuid).await else {
-            return false;
-        };
-        let mut details = details_arc.write().await;
-        f(&mut details);
-        true
+    /// Subscribe to a task's snapshots.
+    pub async fn subscribe(&self, id: &Uuid) -> Option<watch::Receiver<Snapshot>> {
+        self.tasks.read().await.get(id).cloned()
     }
 
     pub async fn get_task_list(&self) -> Vec<TaskDetails> {
-        let detail_arcs = self.get_all_details_arcs().await;
-
-        let mut task_list = Vec::new();
-        for details_arc in detail_arcs {
-            let details = details_arc.read().await;
-            task_list.push(details.clone());
-        }
-        task_list
-    }
-
-    pub async fn get_task_details(&self, uuid: &Uuid) -> Option<TaskDetails> {
-        debug!("TaskManager: Getting task details for {}", uuid);
-
-        let details_arc = self.get_details_arc(uuid).await?;
-        let details = details_arc.read().await;
-        Some(details.clone())
-    }
-
-    pub async fn get_task_output(&self, uuid: &Uuid) -> Option<TaskOutput> {
-        debug!("TaskManager: Getting task output for {}", uuid);
-        Some(self.get_task_details(uuid).await?.output)
-    }
-
-    /// Add a message to a task's output stream
-    pub async fn add_task_message(
-        &self,
-        uuid: &Uuid,
-        stream_type: OutputStreamType,
-        message: String,
-    ) -> bool {
-        debug!("TaskManager: Adding message to task output for {}", uuid);
-        self.modify_task_details(uuid, |details| {
-            details.output.add_line(stream_type, message);
-        })
-        .await
-    }
-
-    /// Add an info message to a task's stdout
-    pub async fn add_task_info(&self, uuid: &Uuid, message: String) -> bool {
-        self.add_task_message(uuid, OutputStreamType::Stdout, message)
+        self.tasks
+            .read()
             .await
+            .values()
+            .map(|rx| (**rx.borrow()).clone())
+            .collect()
     }
 
-    /// Add a status message to task output
-    pub async fn add_task_status(&self, uuid: &Uuid, message: String) -> bool {
-        self.add_task_message(uuid, OutputStreamType::Status, message)
+    pub async fn get_task_details(&self, id: &Uuid) -> Option<TaskDetails> {
+        self.tasks
+            .read()
             .await
+            .get(id)
+            .map(|rx| (**rx.borrow()).clone())
     }
 
-    /// Add an error status message to task output
-    pub async fn add_task_status_error(&self, uuid: &Uuid, message: String) -> bool {
-        self.add_task_message(uuid, OutputStreamType::StatusError, message)
-            .await
-    }
-
-    /// Add a progress message to task output
-    pub async fn add_task_progress(&self, uuid: &Uuid, message: String) -> bool {
-        self.add_task_message(uuid, OutputStreamType::Progress, message)
-            .await
-    }
-
-    /// Add a formatted progress message with step counter
-    pub async fn add_task_step_progress(
-        &self,
-        uuid: &Uuid,
-        current: u32,
-        total: u32,
-        message: String,
-    ) -> bool {
-        let progress_msg = format!("Step {}/{}: {}", current, total, message);
-        self.add_task_progress(uuid, progress_msg).await
-    }
-
-    /// Add an informational message to task output
-    pub async fn add_task_info_message(&self, uuid: &Uuid, message: String) -> bool {
-        self.add_task_message(uuid, OutputStreamType::Info, message)
-            .await
-    }
-
-    pub async fn get_task_handle(
-        &self,
-        uuid: &Uuid,
-    ) -> Option<Arc<RwLock<tokio::task::JoinHandle<()>>>> {
-        let processes = self.processes.read().await;
-        let task_state = processes.get(uuid);
-        task_state?;
-        let task_state = task_state.unwrap();
-        task_state.handle.clone()
-    }
-
-    /// Set task state to finished with completion details
-    async fn set_task_finished(
-        details: &Arc<RwLock<TaskDetails>>,
-        exit_code: Option<i32>,
-        state: State,
-    ) {
-        debug!(
-            "TaskManager: Setting task finished for {}",
-            details.read().await.id
-        );
-
-        let start_time = details.read().await.start_time;
-        let mut details_guard = details.write().await;
-
-        let finish_time = chrono::Utc::now();
-        details_guard.last_exit_code = exit_code;
-        details_guard.finish_time = Some(finish_time);
-        details_guard.state = state.clone();
-
-        // Record metrics
-        let duration_secs = finish_time
-            .signed_duration_since(start_time)
-            .num_milliseconds() as f64
-            / 1000.0;
-        let failed = matches!(state, State::Failed);
-        metrics::metrics().record_task_finished(duration_secs, failed);
-    }
-
-    pub async fn start_process(
+    /// Run `cmd` as a step of the task behind `writer`. Output lines and the
+    /// exit code are reported to the task; the task state is never changed
+    /// here (that is the owner's job). Resolves to the exit code.
+    pub fn start_process(
         &self,
         cwd: &Path,
         cmd: &str,
         args: &[&str],
         env: &HashMap<String, String>,
-        details: Arc<RwLock<TaskDetails>>,
-    ) -> Uuid {
-        self.start_process_with_settings(cwd, cmd, args, env, details, &OutputSettings::default())
-            .await
-    }
-
-    pub async fn start_process_with_settings(
-        &self,
-        cwd: &Path,
-        cmd: &str,
-        args: &[&str],
-        env: &HashMap<String, String>,
-        details: Arc<RwLock<TaskDetails>>,
-        _output_settings: &OutputSettings,
-    ) -> Uuid {
+        writer: TaskWriter,
+    ) -> tokio::task::JoinHandle<anyhow::Result<i32>> {
         let cwd = cwd.to_path_buf();
         let cmd = cmd.to_string();
-        let args = args.iter().map(|s| s.to_string()).collect::<Vec<String>>();
+        let args: Vec<String> = args.iter().map(|s| s.to_string()).collect();
         let env = env.clone();
-        let id = details.read().await.id;
 
-        {
-            debug!("details write lock, setting state to running");
-            let mut details = details.write().await;
-            details.state = State::Running;
-        }
-
-        let handle = {
-            let details = details.clone();
-            let messenger = self.messenger.clone();
-            let task_manager = self.clone(); // Clone the TaskManager for cleanup
-
-            tokio::task::spawn(async move {
-                info!(
-                    "Starting process with uuid {} in folder {}: {:?} {}",
-                    &id,
-                    cwd.display(),
-                    cmd,
-                    args.join(" ")
-                );
-                let details = details.clone();
-                let messenger_for_spawn = messenger.clone();
-                let exit_result = spawn_process(
-                    &cwd,
-                    &cmd,
-                    &args,
-                    &env,
-                    &details,
-                    messenger_for_spawn.clone(),
-                )
+        tokio::spawn(async move {
+            info!(
+                task_id = %writer.id(),
+                "Starting process in {}: {} {}",
+                cwd.display(),
+                cmd,
+                args.join(" ")
+            );
+            writer
+                .step_started(format!("{} {}", cmd, args.join(" ")))
                 .await;
 
-                handle_task_completion(&details, &messenger, &task_manager, id, exit_result).await;
-            })
-        };
-        {
-            self.add_task(&id, details.clone(), Some(Arc::new(RwLock::new(handle))))
-                .await;
-        }
-
-        id
-    }
-
-    pub async fn add_task(
-        &self,
-        id: &Uuid,
-        details: Arc<RwLock<TaskDetails>>,
-        handle: Option<Arc<RwLock<tokio::task::JoinHandle<()>>>>,
-    ) {
-        let mut processes = self.processes.write().await;
-        let task_state = TaskState { details, handle };
-        processes.insert(*id, task_state);
-
-        metrics::metrics().record_task_added(processes.len());
-    }
-
-    pub async fn add_task_with_output(
-        &self,
-        id: &Uuid,
-        details: Arc<RwLock<TaskDetails>>,
-        handle: Option<Arc<RwLock<tokio::task::JoinHandle<()>>>>,
-        _output: Arc<RwLock<TaskOutput>>,
-    ) {
-        // Output is now embedded in TaskDetails, so we ignore the separate output parameter
-        self.add_task(id, details, handle).await;
-    }
-
-    #[instrument]
-    pub async fn run_cleanup_task(&self, interval: SchedulerInterval) {
-        let ttl = interval.into();
-
-        // Step 1: Collect task states with minimal locking (read lock only)
-        let task_states: Vec<(Uuid, TaskState)> = {
-            let processes = self.processes.read().await;
-            processes
-                .iter()
-                .map(|(uuid, state)| (*uuid, state.clone()))
-                .collect()
-        };
-        // Lock released immediately after collecting
-
-        // Step 2: Check each task without holding any locks
-        let mut to_remove = vec![];
-        for (uuid, state) in task_states {
-            if let Some(handle) = &state.handle {
-                // Check if handle is finished (async operation without locks)
-                let is_finished = handle.read().await.is_finished();
-
-                if is_finished {
-                    // Check finish time (async operation without locks)
-                    let details = state.details.read().await;
-                    let should_remove = details.finish_time.is_some_and(|finish_time| {
-                        chrono::Utc::now().signed_duration_since(finish_time) > ttl
-                    });
-
-                    if should_remove {
-                        // Abort the handle (async operation without locks)
-                        handle.write().await.abort();
-                        to_remove.push(uuid);
-                    }
+            let result = run_process(&cwd, &cmd, &args, &env, &writer).await;
+            match &result {
+                Ok(code) => writer.subprocess_exited(Some(*code)).await,
+                Err(e) => {
+                    writer.status_error(format!("Process failed: {e:#}")).await;
+                    writer.subprocess_exited(None).await;
                 }
             }
-        }
+            result
+        })
+    }
 
-        // Step 3: Remove tasks with a write lock (minimal time)
-        if !to_remove.is_empty() {
-            let mut processes = self.processes.write().await;
-            for uuid in to_remove {
-                processes.remove(&uuid);
-            }
-            let active_count = processes.len();
-            drop(processes); // Release lock before recording metrics
-
-            metrics::metrics().record_task_cleanup(active_count);
+    /// Drop terminal tasks whose finish time is older than the TTL.
+    #[instrument(skip(self))]
+    pub async fn run_cleanup_task(&self, interval: SchedulerInterval) {
+        let ttl: chrono::Duration = interval.into();
+        let now = chrono::Utc::now();
+        let mut tasks = self.tasks.write().await;
+        let before = tasks.len();
+        tasks.retain(|_, rx| {
+            let task = rx.borrow();
+            task.state == State::Running
+                || task
+                    .finish_time
+                    .is_none_or(|t| now.signed_duration_since(t) <= ttl)
+        });
+        if tasks.len() != before {
+            debug!("Cleaned up {} finished tasks", before - tasks.len());
+            metrics::metrics().record_task_cleanup(tasks.len());
         }
-        // Write lock released immediately
     }
 }
 
-async fn spawn_process(
-    cwd: &PathBuf,
+async fn run_process(
+    cwd: &Path,
     cmd: &str,
-    args: &Vec<String>,
+    args: &[String],
     env: &HashMap<String, String>,
-    details: &Arc<RwLock<TaskDetails>>,
-    _messenger: WebSocketMessenger,
+    writer: &TaskWriter,
 ) -> anyhow::Result<i32> {
     let mut child = Command::new(cmd)
         .args(args)
@@ -395,43 +147,35 @@ async fn spawn_process(
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .spawn()
-        .expect("Failed to start command");
+        .map_err(|e| anyhow::anyhow!("failed to start `{cmd}`: {e}"))?;
 
-    let stdout = child.stdout.take().expect("Failed to get stdout");
-    let stderr = child.stderr.take().expect("Failed to get stderr");
-    {
-        let details = details.clone();
-        let task_id = {
-            let details_guard = details.read().await;
-            details_guard.id
-        };
-        tokio::spawn(async move {
-            read_unified_output(details.clone(), stdout, OutputStreamType::Stdout, task_id).await;
-        });
-    }
+    let stdout = child.stdout.take().expect("stdout is piped");
+    let stderr = child.stderr.take().expect("stderr is piped");
+    let out_pump = tokio::spawn(pump_output(
+        writer.clone(),
+        stdout,
+        OutputStreamType::Stdout,
+    ));
+    let err_pump = tokio::spawn(pump_output(
+        writer.clone(),
+        stderr,
+        OutputStreamType::Stderr,
+    ));
 
-    {
-        let details = details.clone();
-        let task_id = {
-            let details_guard = details.read().await;
-            details_guard.id
-        };
-        tokio::spawn(async move {
-            read_unified_output(details.clone(), stderr, OutputStreamType::Stderr, task_id).await;
-        });
-    }
-    // Wait for the command to complete
     let status = child.wait().await?;
+    // Both pipes close on exit; join so every line is in the actor before
+    // the exit is reported.
+    let _ = tokio::join!(out_pump, err_pump);
 
-    let exit_code = status.code().unwrap_or_default();
-    Ok(exit_code)
+    status
+        .code()
+        .ok_or_else(|| anyhow::anyhow!("`{cmd}` was terminated by a signal"))
 }
 
-async fn read_unified_output(
-    details: Arc<RwLock<TaskDetails>>,
+async fn pump_output(
+    writer: TaskWriter,
     stream: impl AsyncRead + Unpin,
     stream_type: OutputStreamType,
-    task_id: uuid::Uuid,
 ) {
     const BATCH_SIZE: usize = 20;
     const FLUSH_INTERVAL_MS: u64 = 100;
@@ -439,34 +183,140 @@ async fn read_unified_output(
     let mut reader = BufReader::new(stream).lines();
     let mut buffer = TimedBuffer::new(BATCH_SIZE, FLUSH_INTERVAL_MS);
 
-    while let Some(line_result) = reader.next_line().await.transpose() {
-        match line_result {
-            Ok(line) => {
+    loop {
+        match reader.next_line().await {
+            Ok(Some(line)) => {
                 buffer.push((stream_type, line));
-
                 if buffer.should_flush() {
-                    add_output_lines(&details, buffer.flush(), task_id).await;
+                    writer.output_lines(buffer.flush()).await;
                 }
             }
+            Ok(None) => break,
             Err(e) => {
-                // Flush remaining buffer before error message
-                if buffer.has_data() {
-                    add_output_lines(&details, buffer.flush(), task_id).await;
-                }
-                add_output_line(
-                    &details,
-                    OutputStreamType::Stderr,
-                    format!("Error reading output: {}", e),
-                    task_id,
-                )
-                .await;
-                break;
+                writer.output_lines(buffer.flush()).await;
+                writer
+                    .output(
+                        OutputStreamType::Stderr,
+                        format!("Error reading output: {}", e),
+                    )
+                    .await;
+                return;
             }
         }
     }
+    writer.output_lines(buffer.flush()).await;
+}
 
-    // Flush any remaining buffered lines when stream ends
-    if buffer.has_data() {
-        add_output_lines(&details, buffer.flush(), task_id).await;
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::test_utils::create_test_websocket_messenger;
+    use crate::tasks::actor::Outcome;
+    use std::time::Duration;
+
+    async fn wait_for(
+        rx: &mut watch::Receiver<Snapshot>,
+        pred: impl Fn(&TaskDetails) -> bool,
+    ) -> Snapshot {
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if pred(&rx.borrow()) {
+                    return rx.borrow().clone();
+                }
+                rx.changed().await.unwrap();
+            }
+        })
+        .await
+        .expect("snapshot never satisfied predicate")
+    }
+
+    #[tokio::test]
+    async fn subprocess_exit_does_not_finish_task() {
+        let manager = TaskManager::new(create_test_websocket_messenger());
+        let (handle, mut rx) = manager.create_task(TaskDetails::default()).await;
+
+        let code = manager
+            .start_process(
+                Path::new("."),
+                "sh",
+                &["-c", "echo one; echo two >&2; exit 3"],
+                &HashMap::new(),
+                handle.writer().clone(),
+            )
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(code, 3);
+
+        let task = wait_for(&mut rx, |t| t.last_exit_code == Some(3)).await;
+        assert_eq!(task.state, State::Running);
+        let contents: Vec<_> = task
+            .output
+            .lines
+            .iter()
+            .filter(|l| {
+                matches!(
+                    l.stream,
+                    OutputStreamType::Stdout | OutputStreamType::Stderr
+                )
+            })
+            .map(|l| l.content.as_str())
+            .collect();
+        assert!(
+            contents.contains(&"one") && contents.contains(&"two"),
+            "{contents:?}"
+        );
+
+        handle.terminate(Outcome::finished("done")).await;
+        let task = wait_for(&mut rx, |t| t.state != State::Running).await;
+        assert_eq!(task.state, State::Finished);
+        assert_eq!(
+            manager.get_task_details(&task.id).await.unwrap().state,
+            State::Finished
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_binary_is_reported_not_panicked() {
+        let manager = TaskManager::new(create_test_websocket_messenger());
+        let (handle, mut rx) = manager.create_task(TaskDetails::default()).await;
+        let result = manager
+            .start_process(
+                Path::new("."),
+                "/definitely/not/here",
+                &[],
+                &HashMap::new(),
+                handle.writer().clone(),
+            )
+            .await
+            .unwrap();
+        assert!(result.is_err());
+        let task = wait_for(&mut rx, |t| {
+            t.output
+                .lines
+                .iter()
+                .any(|l| l.content.contains("failed to start"))
+        })
+        .await;
+        assert_eq!(task.state, State::Running);
+    }
+
+    #[tokio::test]
+    async fn cleanup_removes_only_expired_terminal_tasks() {
+        let manager = TaskManager::new(create_test_websocket_messenger());
+        let (running, _) = manager.create_task(TaskDetails::default()).await;
+        let (done, mut rx) = manager.create_task(TaskDetails::default()).await;
+        done.terminate(Outcome::finished("done")).await;
+        wait_for(&mut rx, |t| t.state != State::Running).await;
+
+        manager.run_cleanup_task(SchedulerInterval::Hours(1)).await;
+        assert_eq!(manager.get_task_list().await.len(), 2);
+
+        manager
+            .run_cleanup_task(SchedulerInterval::Seconds(0))
+            .await;
+        let left = manager.get_task_list().await;
+        assert_eq!(left.len(), 1);
+        assert_eq!(left[0].id, running.id());
     }
 }

--- a/scotty/src/tasks/mod.rs
+++ b/scotty/src/tasks/mod.rs
@@ -1,3 +1,4 @@
+pub mod actor;
 pub mod manager;
 pub mod output_streaming;
 pub mod timed_buffer;

--- a/scotty/src/tasks/output_streaming.rs
+++ b/scotty/src/tasks/output_streaming.rs
@@ -1,56 +1,33 @@
-use tokio::sync::mpsc;
-use tracing::{info, warn};
+//! Streams a task's output lines to one WebSocket client by following the
+//! task actor's snapshot channel. The stream ends once the task is terminal
+//! and every line has been sent, so the final status line is never lost.
+
+use tracing::info;
 use uuid::Uuid;
 
 use crate::app_state::SharedAppState;
-use crate::tasks::timed_buffer::TimedBuffer;
+use scotty_core::tasks::task_details::State;
 use scotty_core::websocket::message::WebSocketMessage;
 use scotty_types::{OutputLine, TaskOutputData};
 
 use thiserror::Error;
 
-/// Error types for task output streaming operations
 #[derive(Error, Debug, Clone)]
-#[allow(dead_code)]
 pub enum TaskOutputStreamError {
     #[error("Task '{task_id}' not found")]
     TaskNotFound { task_id: Uuid },
-
-    #[error("Failed to send command to stream: {reason}")]
-    CommandSendFailed { reason: String },
-
-    #[error("Task output access failed: {reason}")]
-    OutputAccessFailed { reason: String },
 }
 
-/// Result type alias for task output streaming operations
 pub type TaskOutputStreamResult<T> = Result<T, TaskOutputStreamError>;
 
-/// Commands that can be sent to a task output stream
-#[derive(Debug)]
-#[allow(dead_code)]
-pub enum TaskOutputStreamCommand {
-    Stop,
-}
-
-/// Service for managing task output streams
-#[derive(Debug, Clone)]
-pub struct TaskOutputStreamingService {
-    // No persistent state needed - each stream is independent
-}
-
-impl Default for TaskOutputStreamingService {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+#[derive(Debug, Clone, Default)]
+pub struct TaskOutputStreamingService;
 
 impl TaskOutputStreamingService {
     pub fn new() -> Self {
-        Self {}
+        Self
     }
 
-    /// Start streaming task output to a client
     pub async fn start_task_output_stream(
         &self,
         app_state: &SharedAppState,
@@ -63,253 +40,82 @@ impl TaskOutputStreamingService {
             task_id, client_id, from_beginning
         );
 
-        // Check if task exists
-        let task_output = app_state
+        let mut rx = app_state
             .task_manager
-            .get_task_output(&task_id)
+            .subscribe(&task_id)
             .await
             .ok_or(TaskOutputStreamError::TaskNotFound { task_id })?;
+        let mut current = rx.borrow_and_update().clone();
 
-        // Get task state
-        let task_details = app_state
-            .task_manager
-            .get_task_details(&task_id)
-            .await
-            .ok_or(TaskOutputStreamError::TaskNotFound { task_id })?;
-
-        // Send stream started notification
         let _ = app_state
             .messenger
             .send_to_client(
                 client_id,
                 WebSocketMessage::TaskOutputStreamStarted {
                     task_id,
-                    total_lines: task_output.total_lines_processed,
+                    total_lines: current.output.total_lines_processed,
                 },
             )
             .await;
 
-        // Create channel for controlling the stream
-        let (_tx, mut rx) = mpsc::channel::<TaskOutputStreamCommand>(1);
-
-        // Clone what we need for the async task
         let app_state = app_state.clone();
-        let output_collection_active = task_details.output_collection_active;
-
-        // Start the streaming task
         crate::metrics::spawn_instrumented(async move {
             crate::metrics::metrics().record_task_output_stream_started();
-            info!(
-                "Task output streaming task started for task {} (output_collection_active: {})",
-                task_id, output_collection_active
-            );
 
-            let mut last_sent_sequence = 0u64;
-            let mut buffer = TimedBuffer::new(10, 100); // 10 lines or 100ms
-
-            // Send historical data if requested
-            if from_beginning {
-                if let Some(task_output) = app_state.task_manager.get_task_output(&task_id).await {
-                    let historical_lines: Vec<OutputLine> = task_output.lines.into_iter().collect();
-
-                    if !historical_lines.is_empty() {
-                        info!(
-                            "Sending {} historical lines for task {}",
-                            historical_lines.len(),
-                            task_id
-                        );
-
-                        // Send historical lines in batches
-                        const BATCH_SIZE: usize = 1000;
-                        let chunks = historical_lines.chunks(BATCH_SIZE);
-                        let total_chunks = chunks.len();
-
-                        for (i, chunk) in chunks.enumerate() {
-                            let is_last_batch = i == total_chunks - 1;
-                            let chunk_len = chunk.len() as u64;
-                            let _ = app_state
-                                .messenger
-                                .send_to_client(
-                                    client_id,
-                                    WebSocketMessage::TaskOutputData(TaskOutputData {
-                                        task_id,
-                                        lines: chunk.to_vec(),
-                                        is_historical: true,
-                                        has_more: !is_last_batch,
-                                    }),
-                                )
-                                .await;
-                            crate::metrics::metrics().record_task_output_lines(chunk_len as usize);
-                        }
-
-                        // Update last sent sequence to the last historical line
-                        if let Some(last_line) = historical_lines.last() {
-                            last_sent_sequence = last_line.sequence + 1;
-                        }
-                    }
+            let send = |lines: Vec<OutputLine>, is_historical: bool, has_more: bool| {
+                let app_state = app_state.clone();
+                async move {
+                    let count = lines.len();
+                    let _ = app_state
+                        .messenger
+                        .send_to_client(
+                            client_id,
+                            WebSocketMessage::TaskOutputData(TaskOutputData {
+                                task_id,
+                                lines,
+                                is_historical,
+                                has_more,
+                            }),
+                        )
+                        .await;
+                    crate::metrics::metrics().record_task_output_lines(count);
                 }
-            }
+            };
 
-            // If output collection is not active, we're done after sending historical data
-            if !output_collection_active {
-                info!(
-                    "Output collection inactive for task {}, ending stream after historical data",
-                    task_id
-                );
+            // Sequence of the next line to send. Lines are appended in
+            // sequence order, so everything below it has been sent.
+            let mut next_sequence = if from_beginning {
+                const BATCH_SIZE: usize = 1000;
+                let chunks: Vec<_> = current.output.lines.chunks(BATCH_SIZE).collect();
+                let total = chunks.len();
+                for (i, chunk) in chunks.into_iter().enumerate() {
+                    send(chunk.to_vec(), true, i + 1 < total).await;
+                }
+                current.output.lines.last().map_or(0, |l| l.sequence + 1)
+            } else {
+                current.output.lines.last().map_or(0, |l| l.sequence + 1)
+            };
 
-                let _ = app_state
-                    .messenger
-                    .send_to_client(
-                        client_id,
-                        WebSocketMessage::TaskOutputStreamEnded {
-                            task_id,
-                            reason: "Output collection completed".to_string(),
-                        },
-                    )
-                    .await;
-                crate::metrics::metrics().record_task_output_stream_ended();
-                return;
-            }
-
-            // Set up timing for live streaming
-            let flush_interval = tokio::time::Duration::from_millis(100);
-            let mut flush_timer = tokio::time::interval(flush_interval);
-            flush_timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-
-            let poll_interval = tokio::time::Duration::from_millis(100);
-            let mut poll_timer = tokio::time::interval(poll_interval);
-            poll_timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-
-            info!(
-                "Starting live streaming for task {} from sequence {}",
-                task_id, last_sent_sequence
-            );
-
-            // Live streaming loop
             loop {
-                tokio::select! {
-                    // Check for control commands
-                    Some(cmd) = rx.recv() => {
-                        match cmd {
-                            TaskOutputStreamCommand::Stop => {
-                                info!("Stopping task output stream {} by external request", task_id);
-                                break;
-                            }
-                        }
-                    }
-                    // Check if we should flush the buffer based on time
-                    _ = flush_timer.tick() => {
-                        if buffer.has_data() && buffer.should_flush() {
-                            let lines_to_send = buffer.flush();
-                            let lines_count = lines_to_send.len();
-                            if lines_count > 0 {
-                                let _ = app_state.messenger.send_to_client(
-                                    client_id,
-                                    WebSocketMessage::TaskOutputData(TaskOutputData {
-                                        task_id,
-                                        lines: lines_to_send,
-                                        is_historical: false,
-                                        has_more: false,
-                                    }),
-                                ).await;
-                                crate::metrics::metrics().record_task_output_lines(lines_count);
-                            }
-                        }
-                    }
-                    // Poll for new task output
-                    _ = poll_timer.tick() => {
-                        // First, check for new output BEFORE checking if collection is active
-                        // This ensures we capture any final messages added just before completion
-                        let mut should_end_stream = false;
-
-                        if let Some(_task_output) = app_state.task_manager.get_task_output(&task_id).await {
-                            let details_guard = {
-                                // Get the processes lock and clone the details Arc
-                                let processes = app_state.task_manager.processes.read().await;
-                                processes.get(&task_id).map(|task_state| task_state.details.clone())
-                            };
-
-                            if let Some(details_arc) = details_guard {
-                                let details = details_arc.read().await;
-                                let output = &details.output;
-
-                                // Check if we should end after this poll
-                                if !details.output_collection_active {
-                                    should_end_stream = true;
-                                }
-
-                                // Find new lines since last_sent_sequence
-                                let new_lines: Vec<OutputLine> = output
-                                    .lines
-                                    .iter()
-                                    .filter(|line| line.sequence >= last_sent_sequence)
-                                    .cloned()
-                                    .collect();
-
-                                if !new_lines.is_empty() {
-                                    for line in &new_lines {
-                                        buffer.push(line.clone());
-                                    }
-
-                                    // Update last sent sequence
-                                    if let Some(last_line) = new_lines.last() {
-                                        last_sent_sequence = last_line.sequence + 1;
-                                    }
-
-                                    // Send immediately if buffer should flush
-                                    if buffer.should_flush() {
-                                        let lines_to_send = buffer.flush();
-                                        let lines_count = lines_to_send.len();
-                                        let _ = app_state.messenger.send_to_client(
-                                            client_id,
-                                            WebSocketMessage::TaskOutputData(TaskOutputData {
-                                                task_id,
-                                                lines: lines_to_send,
-                                                is_historical: false,
-                                                has_more: false,
-                                            }),
-                                        ).await;
-                                        crate::metrics::metrics().record_task_output_lines(lines_count);
-                                    }
-                                }
-                            } else {
-                                warn!("Task {} no longer exists, ending stream", task_id);
-                                should_end_stream = true;
-                            }
-                        } else {
-                            warn!("Task output for {} no longer available, ending stream", task_id);
-                            should_end_stream = true;
-                        }
-
-                        // End stream after processing all available output
-                        if should_end_stream {
-                            info!("Output collection disabled for task {}, ending stream after final poll", task_id);
-                            break;
-                        }
-                    }
+                let start = current
+                    .output
+                    .lines
+                    .partition_point(|l| l.sequence < next_sequence);
+                let new_lines = &current.output.lines[start..];
+                if let Some(last) = new_lines.last() {
+                    next_sequence = last.sequence + 1;
+                    send(new_lines.to_vec(), false, false).await;
                 }
+                if current.state != State::Running {
+                    break;
+                }
+                // Err means the actor is gone; whatever we have is final.
+                if rx.changed().await.is_err() {
+                    break;
+                }
+                current = rx.borrow_and_update().clone();
             }
 
-            // Send any remaining buffered lines
-            if buffer.has_data() {
-                let lines_to_send = buffer.flush();
-                let lines_count = lines_to_send.len();
-                let _ = app_state
-                    .messenger
-                    .send_to_client(
-                        client_id,
-                        WebSocketMessage::TaskOutputData(TaskOutputData {
-                            task_id,
-                            lines: lines_to_send,
-                            is_historical: false,
-                            has_more: false,
-                        }),
-                    )
-                    .await;
-                crate::metrics::metrics().record_task_output_lines(lines_count);
-            }
-
-            // Send stream ended message
             let _ = app_state
                 .messenger
                 .send_to_client(
@@ -320,14 +126,78 @@ impl TaskOutputStreamingService {
                     },
                 )
                 .await;
-
             crate::metrics::metrics().record_task_output_stream_ended();
-            info!(
-                "Task output stream for task {} ended and cleaned up",
-                task_id
-            );
+            info!("Task output stream for task {} ended", task_id);
         });
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app_state::WebSocketClient;
+    use crate::tasks::actor::Outcome;
+    use scotty_core::output::OutputStreamType;
+    use scotty_core::tasks::task_details::TaskDetails;
+    use std::time::Duration;
+
+    /// Lines written after the stream starts, including the final status line,
+    /// all arrive before `TaskOutputStreamEnded`.
+    #[tokio::test]
+    async fn stream_delivers_every_line_before_ending() {
+        let app_state = crate::api::test_utils::create_test_app_state_with_config(
+            "tests/test_bearer_auth",
+            None,
+        )
+        .await;
+        let client_id = Uuid::new_v4();
+        let (tx, mut client_rx) = tokio::sync::broadcast::channel(64);
+        app_state
+            .messenger
+            .add_client(client_id, WebSocketClient::new(tx))
+            .await;
+
+        let (handle, _) = app_state
+            .task_manager
+            .create_task(TaskDetails::default())
+            .await;
+        handle.writer().status("before").await;
+
+        app_state
+            .task_output_service
+            .start_task_output_stream(&app_state, handle.id(), client_id, true)
+            .await
+            .unwrap();
+
+        for i in 0..3 {
+            handle
+                .writer()
+                .output(OutputStreamType::Stdout, format!("line {i}"))
+                .await;
+        }
+        handle.terminate(Outcome::finished("done")).await;
+
+        let mut contents = vec![];
+        let mut ended = false;
+        while !ended {
+            let msg = tokio::time::timeout(Duration::from_secs(5), client_rx.recv())
+                .await
+                .expect("stream never ended")
+                .unwrap();
+            let text = match msg {
+                axum::extract::ws::Message::Text(t) => t.to_string(),
+                other => panic!("unexpected frame {other:?}"),
+            };
+            match serde_json::from_str::<WebSocketMessage>(&text).unwrap() {
+                WebSocketMessage::TaskOutputData(data) => {
+                    contents.extend(data.lines.into_iter().map(|l| l.content));
+                }
+                WebSocketMessage::TaskOutputStreamEnded { .. } => ended = true,
+                _ => {}
+            }
+        }
+        assert_eq!(contents, ["before", "line 0", "line 1", "line 2", "done"]);
     }
 }

--- a/scotty/src/tasks/timed_buffer.rs
+++ b/scotty/src/tasks/timed_buffer.rs
@@ -65,11 +65,6 @@ impl<T> TimedBuffer<T> {
         std::mem::take(&mut self.items)
     }
 
-    /// Check if the buffer contains any items
-    pub fn has_data(&self) -> bool {
-        !self.items.is_empty()
-    }
-
     /// Get the number of items currently in the buffer
     #[allow(dead_code)]
     pub fn len(&self) -> usize {
@@ -120,12 +115,12 @@ mod tests {
         let mut buffer = TimedBuffer::new(10, 100);
         assert!(buffer.is_empty());
         assert_eq!(buffer.len(), 0);
-        assert!(!buffer.has_data());
+        assert!(buffer.is_empty());
 
         buffer.push(1);
         buffer.push(2);
         assert!(!buffer.is_empty());
         assert_eq!(buffer.len(), 2);
-        assert!(buffer.has_data());
+        assert!(!buffer.is_empty());
     }
 }

--- a/scotty/tests/test_scoped_create_visibility.rs
+++ b/scotty/tests/test_scoped_create_visibility.rs
@@ -1,0 +1,158 @@
+//! Regression test for factorial-io/scotty#894: an app created with a scoped
+//! (non-admin) bearer token must be visible to that same token as soon as the
+//! create task reports completion, not only after the next scheduled app scan.
+//!
+//! Marked #[ignore] because it drives a real `docker compose up`.
+//! Run locally with: cargo test --test test_scoped_create_visibility -- --ignored --nocapture
+
+use std::time::{Duration, Instant};
+
+use axum_test::TestServer;
+use base64::prelude::*;
+use scotty::api::router::ApiRoutes;
+use scotty::api::test_utils::create_test_app_state_with_settings;
+use scotty::docker::loadbalancer::app_proxy_network_name;
+use scotty_types::State;
+
+/// `identifier:client-a` has the `developer` role in scope `client-a` only.
+const SCOPED_TOKEN: &str = "client-a-secure-token-456";
+/// `identifier:admin` may destroy.
+const ADMIN_TOKEN: &str = "test-bearer-token-123";
+
+#[tokio::test]
+#[ignore]
+async fn scoped_token_can_read_app_it_just_created() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .try_init();
+    let root = std::env::temp_dir().join(format!("scotty-894-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&root).unwrap();
+
+    let config = config::Config::builder()
+        .add_source(config::File::with_name("tests/test_bearer_auth"))
+        .build()
+        .unwrap();
+    let mut settings: scotty::settings::config::Settings = config.try_deserialize().unwrap();
+    settings.apps.root_folder = root.to_str().unwrap().to_string();
+    let app_name = "issue-894";
+    // Drop guard so containers, network and temp dir go away on any panic.
+    let _cleanup = Cleanup {
+        app_dir: root.join(app_name),
+        root: root.clone(),
+        network: app_proxy_network_name(&settings.traefik.network, app_name),
+    };
+
+    let app_state = create_test_app_state_with_settings(settings, None).await;
+    let server = TestServer::new(ApiRoutes::create(app_state.clone()));
+
+    let compose = "services:\n  web:\n    image: alpine:3\n    command: sleep 3600\n";
+
+    let response = server
+        .post("/api/v1/authenticated/apps/create")
+        .authorization_bearer(SCOPED_TOKEN)
+        .json(&serde_json::json!({
+            "app_name": app_name,
+            "settings": {
+                "public_services": [],
+                "domain": "",
+                "time_to_live": "Forever",
+                "basic_auth": null,
+                "disallow_robots": true,
+                "environment": {},
+                "registry": null,
+                "app_blueprint": null,
+            },
+            "files": { "files": [
+                { "name": "docker-compose.yml", "content": BASE64_STANDARD.encode(compose) }
+            ]},
+            "custom_domains": [],
+            "requested_scopes": ["client-a"],
+        }))
+        .await;
+    assert_eq!(response.status_code(), 200, "{}", response.text());
+    let task_id = response.json::<serde_json::Value>()["task"]["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let created = wait_for_task(&server, &task_id, SCOPED_TOKEN).await;
+    assert_eq!(created.state, State::Finished, "{created:#?}");
+
+    let info = server
+        .get(&format!("/api/v1/authenticated/apps/info/{app_name}"))
+        .authorization_bearer(SCOPED_TOKEN)
+        .await;
+
+    assert_eq!(info.status_code(), 200, "{}", info.text());
+
+    // Exactly one completion: the nested rebuild machine must not have
+    // completed the shared task before the create machine did.
+    let task = app_state
+        .task_manager
+        .get_task_details(&uuid::Uuid::parse_str(&task_id).unwrap())
+        .await
+        .unwrap();
+    let completions = task
+        .output
+        .lines
+        .iter()
+        .filter(|l| l.content.contains("Successfully completed operation"))
+        .count();
+    assert_eq!(completions, 1, "{:#?}", task.output.lines);
+
+    // Destroy removes the app directory before its completion handler runs;
+    // that must not turn a successful destroy into a Failed task.
+    let response = server
+        .get(&format!("/api/v1/authenticated/apps/destroy/{app_name}"))
+        .authorization_bearer(ADMIN_TOKEN)
+        .await;
+    assert_eq!(response.status_code(), 200, "{}", response.text());
+    let task_id = response.json::<serde_json::Value>()["task"]["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let task = wait_for_task(&server, &task_id, ADMIN_TOKEN).await;
+    assert_eq!(task.state, State::Finished, "{task:#?}");
+    assert!(!root.join(app_name).exists());
+}
+
+/// Poll quickly: before the fix the task flipped to Finished after each
+/// subprocess, so the window in which apps/info fails is short.
+async fn wait_for_task(
+    server: &TestServer,
+    task_id: &str,
+    token: &str,
+) -> scotty_types::TaskDetails {
+    let deadline = Instant::now() + Duration::from_secs(120);
+    loop {
+        let task: scotty_types::TaskDetails = server
+            .get(&format!("/api/v1/authenticated/task/{task_id}"))
+            .authorization_bearer(token)
+            .await
+            .json();
+        if task.state != State::Running {
+            return task;
+        }
+        assert!(Instant::now() < deadline, "task did not finish");
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+struct Cleanup {
+    app_dir: std::path::PathBuf,
+    root: std::path::PathBuf,
+    network: String,
+}
+
+impl Drop for Cleanup {
+    fn drop(&mut self) {
+        let _ = std::process::Command::new("docker")
+            .args(["compose", "down", "-v", "--remove-orphans"])
+            .current_dir(&self.app_dir)
+            .output();
+        let _ = std::process::Command::new("docker")
+            .args(["network", "rm", &self.network])
+            .output();
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}

--- a/scottyctl/src/api.rs
+++ b/scottyctl/src/api.rs
@@ -287,7 +287,9 @@ pub async fn wait_for_task(
                     }
                     State::Failed => {
                         ui.set_status("Task failed", Status::Failed);
-                        if let Some(exit_code) = task.last_exit_code {
+                        // A task can fail without a failing subprocess; do not
+                        // show a misleading "Exit code: 0".
+                        if let Some(exit_code) = task.last_exit_code.filter(|c| *c != 0) {
                             ui.eprintln(format!("Exit code: {}", exit_code).red().to_string());
                         }
                     }
@@ -295,10 +297,13 @@ pub async fn wait_for_task(
                 }
 
                 // Return error if task failed
-                if let Some(exit_code) = task.last_exit_code {
-                    if exit_code != 0 {
-                        return Err(anyhow::anyhow!("Task failed with exit code {}", exit_code));
-                    }
+                // The server may fail a task without a failing subprocess (e.g. a
+                // panic or a failed app-data refresh), so the state is authoritative.
+                if task.state == State::Failed || task.last_exit_code.is_some_and(|c| c != 0) {
+                    return Err(match task.last_exit_code {
+                        Some(c) if c != 0 => anyhow::anyhow!("Task failed with exit code {}", c),
+                        _ => anyhow::anyhow!("Task failed"),
+                    });
                 }
             } else {
                 // Poll every 500ms
@@ -339,17 +344,22 @@ pub async fn wait_for_task(
                     }
                     State::Failed => {
                         ui.set_status("Task failed", Status::Failed);
-                        if let Some(exit_code) = task.last_exit_code {
+                        // A task can fail without a failing subprocess; do not
+                        // show a misleading "Exit code: 0".
+                        if let Some(exit_code) = task.last_exit_code.filter(|c| *c != 0) {
                             ui.eprintln(format!("Exit code: {}", exit_code).red().to_string());
                         }
                     }
                     State::Running => {} // Should not happen
                 }
 
-                if let Some(exit_code) = task.last_exit_code {
-                    if exit_code != 0 {
-                        return Err(anyhow::anyhow!("Task failed with exit code {}", exit_code));
-                    }
+                // The server may fail a task without a failing subprocess (e.g. a
+                // panic or a failed app-data refresh), so the state is authoritative.
+                if task.state == State::Failed || task.last_exit_code.is_some_and(|c| c != 0) {
+                    return Err(match task.last_exit_code {
+                        Some(c) if c != 0 => anyhow::anyhow!("Task failed with exit code {}", c),
+                        _ => anyhow::anyhow!("Task failed"),
+                    });
                 }
             } else {
                 tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;


### PR DESCRIPTION
## Summary

Fixes #894 by rebuilding task ownership instead of patching the symptom.

Task state used to live in a shared `Arc<RwLock<TaskDetails>>` written by the state machine, every handler, the subprocess runner and the completion handler, with nobody owning the terminal transition. A subprocess exit could flip a create task to `Finished` before the app's scopes were synced, so a scoped bearer token got 403 on `apps/info` until the next scan. The same root cause hid double completions, a lost final status line, and tasks stuck `Running` after a panic.

### Design

One actor per task (`scotty/src/tasks/actor.rs`, after Alice Ryhl's "Actors with Tokio"):

- The actor owns `TaskDetails`, folds `TaskEvent`s from a bounded mailbox and publishes immutable `Arc<TaskDetails>` snapshots on a `watch` channel.
- `TaskWriter` (Clone) emits output lines, step starts and subprocess exits. `TaskHandle` (not Clone) lives in the state machine `Context` and is the only thing that can terminate a task. Dropping it unterminated fails the task with "aborted unexpectedly", so panics and swallowed errors surface as `Failed`.
- `Terminate` is applied once; the status line, finish time and metric land in the same snapshot as the terminal state.
- `TaskManager` is a registry of snapshot receivers. `start_process` reports output and exit code and returns a `JoinHandle`; it never changes task state.
- Output streaming follows the `watch` channel and ends only after the terminal snapshot.
- Nested rebuild/purge machines (`nested: true`) have no completion handler.
- scottyctl fails on `state == Failed` regardless of exit code.

Design and decisions are in `openspec/changes/task-actor/`. A follow-up proposal, `openspec/changes/linear-operations/`, plans to replace the state machines with plain `async fn`s now that ownership is in the actor; it is documentation only in this PR.

Supersedes #897, which fixed the same issue on top of the old shared-state design.

### Verification

- `cargo test --workspace --no-default-features`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --check`, `bun run check`
- Docker regression test `cargo test --no-default-features --test test_scoped_create_visibility -- --ignored`: scoped token reads its new app, exactly one completion line, destroy ends `Finished`
- New unit tests: actor (4), manager (3), `run_sm` panic/error paths (3), completion handler (2), output streaming (1)
